### PR TITLE
Add password-reset flow, logout hook & cookie refresh

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,3 +1,6 @@
 export const auth = {
     login: () => "/auth/login",
+    logout: () => "/auth/logout",
+    forgotPassword: () => "/auth/forgot-password",
+    resetPassword: () => "/auth/reset-password",
 };

--- a/src/app/routes/AuthRoutes.tsx
+++ b/src/app/routes/AuthRoutes.tsx
@@ -3,6 +3,8 @@ import { withGuestGuard } from "../../hoc/withGuestGuard";
 import { AuthLayout } from "../../layouts/auth/AuthLayout";
 import LoginPage from "../../features/auth/login/pages/LoginPage";
 import ResetPassword from "../../features/auth/reset-password/pages/ResetPassword";
+import ForgotPasswordPage from "../../features/auth/forgot-password/pages/ForgotPasswordPage";
+import ResetPasswordPage from "../../features/auth/forgot-password/pages/ResetPasswordPage";
 
 const ProtectedAuthLayout = withGuestGuard(AuthLayout);
 
@@ -10,7 +12,7 @@ export const authRoutes: RouteObject[] = [
     {
         element: <ProtectedAuthLayout />,
         children: [
-            
+
             {
                 path: "/login",
                 element: <LoginPage />
@@ -18,6 +20,14 @@ export const authRoutes: RouteObject[] = [
             {
                 path: "/reset-password",
                 element: <ResetPassword />
+            },
+            {
+                path: "/forgot-password",
+                element: <ForgotPasswordPage />
+            },
+            {
+                path: "/reset-password/:token",
+                element: <ResetPasswordPage />
             }
         ],
     },

--- a/src/features/auth/forgot-password/formik/forgot-password.schema.ts
+++ b/src/features/auth/forgot-password/formik/forgot-password.schema.ts
@@ -1,0 +1,8 @@
+import * as Yup from 'yup';
+
+export const forgotPasswordValidationSchema = Yup.object({
+    email: Yup.string()
+        .email('Please enter a valid email address')
+        .required('Email is required')
+        .trim(),
+});

--- a/src/features/auth/forgot-password/formik/reset-password-with-token.schema.ts
+++ b/src/features/auth/forgot-password/formik/reset-password-with-token.schema.ts
@@ -1,0 +1,11 @@
+import * as Yup from 'yup';
+
+export const resetPasswordWithTokenValidationSchema = Yup.object({
+    newPassword: Yup.string()
+        .required('New password is required')
+        .min(8, 'Password must be at least 8 characters long'),
+
+    confirmPassword: Yup.string()
+        .required('Please confirm your password')
+        .oneOf([Yup.ref('newPassword')], 'Passwords must match'),
+});

--- a/src/features/auth/forgot-password/pages/ForgotPasswordPage.tsx
+++ b/src/features/auth/forgot-password/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,118 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { Mail } from "lucide-react";
+import { Link } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import InputField from "../../../../common/ui/Input";
+import Login from "../../../../assets/images/Login.png";
+import { forgotPasswordValidationSchema } from "../formik/forgot-password.schema";
+import { useForgotPasswordMutation } from "../../../../state/services/endpoints/auth";
+
+interface ForgotPasswordFormValues {
+  email: string;
+}
+
+const ForgotPasswordPage = () => {
+  const [forgotPassword, { isLoading }] = useForgotPasswordMutation();
+
+  const initialValues: ForgotPasswordFormValues = {
+    email: '',
+  };
+
+  const handleSubmit = async (
+    values: ForgotPasswordFormValues,
+    { setSubmitting, resetForm }: any
+  ) => {
+    try {
+      const response = await forgotPassword(values).unwrap();
+      toast.success(response.message || 'If this email is registered, a reset link has been generated.');
+      resetForm();
+    } catch (error: any) {
+      toast.error(error.data?.message || 'Failed to process forgot password request');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="h-screen bg-gradient-to-br from-sky-50 via-white to-sky-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-7xl h-full max-h-[550px] bg-white rounded-3xl shadow-2xl overflow-hidden flex flex-col lg:flex-row">
+        {/* Left Column - Image */}
+        <div className="hidden lg:flex lg:w-1/2 relative">
+          <div className="flex flex-col justify-center items-center text-white w-full">
+            <div className="w-full h-full flex items-center justify-center">
+              <div className="text-center p-20">
+                <img src={Login} alt="Forgot Password" className="w-full h-auto" />
+              </div>
+            </div>
+          </div>
+          <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-px h-4/4 bg-gradient-to-b from-transparent via-neutral-300 to-transparent"></div>
+        </div>
+
+        {/* Right Column - Forgot Password Form */}
+        <div className="flex-1 flex items-center justify-center p-6 lg:p-12">
+          <div className="w-full max-w-lg">
+            <div className="mb-8 text-center">
+              <h2 className="text-3xl font-semibold text-neutral-900 mb-2">Forgot Password</h2>
+              <p className="text-sm text-neutral-600">Enter your registered email address and we'll generate a password reset link</p>
+            </div>
+
+            <Formik
+              initialValues={initialValues}
+              validationSchema={forgotPasswordValidationSchema}
+              onSubmit={handleSubmit}
+            >
+              {({ values, errors, touched, handleChange, handleBlur, isSubmitting }) => (
+                <Form>
+                  <div className="space-y-4">
+                    <InputField
+                      id="email"
+                      name="email"
+                      type="email"
+                      label="Email"
+                      placeholder="Enter your registered email"
+                      value={values.email}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      error={errors.email}
+                      touched={touched.email}
+                      icon={Mail}
+                      required
+                    />
+
+                    <div className="mt-6">
+                      <Button
+                        type="submit"
+                        variant="primary"
+                        size="md"
+                        loading={isSubmitting || isLoading}
+                        disabled={isSubmitting || isLoading}
+                        fullWidth
+                      >
+                        {isSubmitting || isLoading ? '' : 'Send Reset Link'}
+                      </Button>
+                    </div>
+                  </div>
+                </Form>
+              )}
+            </Formik>
+
+            <div className="mt-6 text-center">
+              <p className="text-sm text-neutral-600">
+                Remembered your password?{' '}
+                <Link
+                  to="/login"
+                  className="text-primary font-medium hover:underline transition-colors duration-200"
+                >
+                  Back to Login
+                </Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/src/features/auth/forgot-password/pages/ResetPasswordPage.tsx
+++ b/src/features/auth/forgot-password/pages/ResetPasswordPage.tsx
@@ -1,0 +1,133 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { Lock } from "lucide-react";
+import { useNavigate, useParams } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import InputField from "../../../../common/ui/Input";
+import Login from "../../../../assets/images/Login.png";
+import { resetPasswordWithTokenValidationSchema } from "../formik/reset-password-with-token.schema";
+import { useResetPasswordMutation } from "../../../../state/services/endpoints/auth";
+
+interface ResetPasswordFormValues {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const ResetPasswordPage = () => {
+  const navigate = useNavigate();
+  const { token } = useParams<{ token: string }>();
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+
+  const initialValues: ResetPasswordFormValues = {
+    newPassword: '',
+    confirmPassword: '',
+  };
+
+  const handleSubmit = async (
+    values: ResetPasswordFormValues,
+    { setSubmitting }: any
+  ) => {
+    if (!token) {
+      toast.error('Reset link is invalid or has expired');
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      const response = await resetPassword({ token, ...values }).unwrap();
+      toast.success(response.message || 'Password has been reset successfully');
+      navigate('/login', { replace: true });
+    } catch (error: any) {
+      toast.error(error.data?.message || 'Failed to reset password');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="h-screen bg-gradient-to-br from-sky-50 via-white to-sky-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-7xl h-full max-h-[550px] bg-white rounded-3xl shadow-2xl overflow-hidden flex flex-col lg:flex-row">
+        {/* Left Column - Image */}
+        <div className="hidden lg:flex lg:w-1/2 relative">
+          <div className="flex flex-col justify-center items-center text-white w-full">
+            <div className="w-full h-full flex items-center justify-center">
+              <div className="text-center p-20">
+                <img src={Login} alt="Reset Password" className="w-full h-auto" />
+              </div>
+            </div>
+          </div>
+          <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-px h-4/4 bg-gradient-to-b from-transparent via-neutral-300 to-transparent"></div>
+        </div>
+
+        {/* Right Column - Reset Password Form */}
+        <div className="flex-1 flex items-center justify-center p-6 lg:p-12">
+          <div className="w-full max-w-lg">
+            <div className="mb-8 text-center">
+              <h2 className="text-3xl font-semibold text-neutral-900 mb-2">Reset Password</h2>
+              <p className="text-sm text-neutral-600">Enter your new password below</p>
+            </div>
+
+            <Formik
+              initialValues={initialValues}
+              validationSchema={resetPasswordWithTokenValidationSchema}
+              onSubmit={handleSubmit}
+            >
+              {({ values, errors, touched, handleChange, handleBlur, isSubmitting }) => (
+                <Form>
+                  <div className="space-y-4">
+                    <InputField
+                      id="newPassword"
+                      name="newPassword"
+                      type="password"
+                      label="New Password"
+                      placeholder="Enter your new password"
+                      value={values.newPassword}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      error={errors.newPassword}
+                      touched={touched.newPassword}
+                      icon={Lock}
+                      showPasswordToggle
+                      required
+                    />
+
+                    <InputField
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      label="Confirm Password"
+                      placeholder="Re-enter your new password"
+                      value={values.confirmPassword}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      error={errors.confirmPassword}
+                      touched={touched.confirmPassword}
+                      icon={Lock}
+                      showPasswordToggle
+                      required
+                    />
+
+                    <div className="mt-6">
+                      <Button
+                        type="submit"
+                        variant="primary"
+                        size="md"
+                        loading={isSubmitting || isLoading}
+                        disabled={isSubmitting || isLoading}
+                        fullWidth
+                      >
+                        {isSubmitting || isLoading ? '' : 'Reset Password'}
+                      </Button>
+                    </div>
+                  </div>
+                </Form>
+              )}
+            </Formik>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/features/auth/login/pages/LoginPage.tsx
+++ b/src/features/auth/login/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import toast from "react-hot-toast";
 import { Formik, Form } from 'formik';
 import { Mail, Lock } from "lucide-react";
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Button from "../../../../common/ui/Button";
 import { UserRole } from "../../../../utils/enum";
 import InputField from "../../../../common/ui/Input";
@@ -33,27 +33,20 @@ const LoginPage = () => {
       const response = await login(values).unwrap();
 
       if (response.data.tokens) {
-        if (response.data.tokens) {
-          setItemInStorage({
-            key: 'accessToken',
-            value: response.data.tokens.accessToken,
-          });
+        setItemInStorage({
+          key: 'accessToken',
+          value: response.data.tokens.accessToken,
+        });
 
-          setItemInStorage({
-            key: 'refreshToken',
-            value: response.data.tokens.refreshToken,
-          });
+        setItemInStorage({
+          key: 'user',
+          value: response.data.user,
+        });
 
-          setItemInStorage({
-            key: 'user',
-            value: response.data.user,
-          });
-
-          setItemInStorage({
-            key: 'userRole',
-            value: response.data.user.role,
-          });
-        }
+        setItemInStorage({
+          key: 'userRole',
+          value: response.data.user.role,
+        });
       }
 
       toast.success(response.message || 'Login successful!');
@@ -138,6 +131,16 @@ const LoginPage = () => {
                         showPasswordToggle
                         required
                       />
+
+                      {/* Forgot Password Link */}
+                      <div className="text-right">
+                        <Link
+                          to="/forgot-password"
+                          className="text-sm text-primary font-medium hover:underline transition-colors duration-200"
+                        >
+                          Forgot Password?
+                        </Link>
+                      </div>
 
                       {/* Login Button */}
                       <div className="mt-6">

--- a/src/features/auth/logout/useLogout.ts
+++ b/src/features/auth/logout/useLogout.ts
@@ -1,0 +1,25 @@
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+import { clearStorage } from "../../../utils/storage";
+import { useLogoutMutation } from "../../../state/services/endpoints/auth";
+
+// Notifies the backend (for the login/logout audit log) before clearing local
+// auth state - best-effort, since a failed network call shouldn't trap the user.
+export function useLogout() {
+    const navigate = useNavigate();
+    const [logoutMutation] = useLogoutMutation();
+
+    const logout = async () => {
+        try {
+            await logoutMutation().unwrap();
+        } catch (error) {
+            console.error('Logout API call failed:', error);
+        } finally {
+            clearStorage();
+            toast.success('Logged out successfully');
+            navigate('/login', { replace: true });
+        }
+    };
+
+    return { logout };
+}

--- a/src/features/faculty/dashboard/pages/FacultyDashboardPage.tsx
+++ b/src/features/faculty/dashboard/pages/FacultyDashboardPage.tsx
@@ -1,22 +1,11 @@
-import toast from "react-hot-toast";
-import { useNavigate } from "react-router-dom";
 import Button from "../../../../common/ui/Button";
-import { clearStorage } from "../../../../utils/storage";
+import { useLogout } from "../../../auth/logout/useLogout";
 
 const FacultyDashboardPage = () => {
-    const navigate = useNavigate();
+    const { logout } = useLogout();
 
     const handleLogout = () => {
-        try {
-            // Clear localStorage data
-            clearStorage();
-
-            toast.success('Logged out successfully');
-            navigate('/login', { replace: true });
-        } catch (error) {
-            console.error('Logout error:', error);
-            toast.error('Failed to logout. Please try again.');
-        }
+        logout();
     };
 
     return (

--- a/src/features/student/dashboard/pages/StudentDashboardPage.tsx
+++ b/src/features/student/dashboard/pages/StudentDashboardPage.tsx
@@ -1,22 +1,11 @@
-import toast from "react-hot-toast";
-import { useNavigate } from "react-router-dom";
 import Button from "../../../../common/ui/Button";
-import { clearStorage } from "../../../../utils/storage";
+import { useLogout } from "../../../auth/logout/useLogout";
 
 const StudentDashboardPage = () => {
-    const navigate = useNavigate();
+    const { logout } = useLogout();
 
     const handleLogout = () => {
-        try {
-            // Clear localStorage data
-            clearStorage();
-
-            toast.success('Logged out successfully');
-            navigate('/login', { replace: true });
-        } catch (error) {
-            console.error('Logout error:', error);
-            toast.error('Failed to logout. Please try again.');
-        }
+        logout();
     };
 
     return (

--- a/src/hoc/withAuthGuard.tsx
+++ b/src/hoc/withAuthGuard.tsx
@@ -8,8 +8,7 @@ export function withAuthGuard<P extends object>(
     const ComponentWithAuthGuard: React.FC<P> = (props) => {
         const checkAuthentication = (): boolean => {
             const accessToken = getItemFromStorage({ key: "accessToken" });
-            const refreshToken = getItemFromStorage({ key: "refreshToken" });
-            return !!(accessToken && refreshToken);
+            return !!accessToken;
         };
 
         const isAuthenticated = checkAuthentication();

--- a/src/hoc/withGuestGuard.tsx
+++ b/src/hoc/withGuestGuard.tsx
@@ -10,8 +10,7 @@ export function withGuestGuard<P extends object>(
     const ComponentWithGuestGuard: React.FC<P> = (props) => {
         const checkAuthentication = (): boolean => {
             const accessToken = getItemFromStorage({ key: "accessToken" });
-            const refreshToken = getItemFromStorage({ key: "refreshToken" });
-            return !!(accessToken && refreshToken);
+            return !!accessToken;
         };
 
         const isAuthenticated = checkAuthentication();

--- a/src/layouts/root/RootLayout.tsx
+++ b/src/layouts/root/RootLayout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
-import { logout } from "../../utils/logout";
+import { useLogout } from "../../features/auth/logout/useLogout";
 import { getItemFromStorage } from "../../utils/storage";
-import { Outlet, useLocation, Link, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, Link } from "react-router-dom";
 import { LogOut, Home, type LucideIcon, GraduationCap, Users, UserCog, ClipboardCheck } from "lucide-react";
 
 interface NavigationItem {
@@ -55,7 +55,7 @@ export interface RootLayoutContext {
 
 export function RootLayout() {
     const location = useLocation();
-    const navigate = useNavigate();
+    const { logout } = useLogout();
 
     const isActiveRoute = (item: NavigationItem): boolean => {
         // If matchPattern is defined, check if current path starts with it
@@ -67,7 +67,7 @@ export function RootLayout() {
     };
 
     const handleLogout = () => {
-        logout(navigate);
+        logout();
     };
 
     const userData = getItemFromStorage({ key: "user" }) as {

--- a/src/state/services/axios-instance.ts
+++ b/src/state/services/axios-instance.ts
@@ -6,6 +6,7 @@ export const createAxiosInstance = (baseUrl: string): AxiosInstance => {
     const instance = axios.create({
         baseURL: baseUrl,
         timeout: 120000,
+        withCredentials: true,
         headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
@@ -24,6 +25,7 @@ export const createAxiosInstance = (baseUrl: string): AxiosInstance => {
     const publicEndpoints = [
         '/auth/login',
         '/auth/refresh-token',
+        '/auth/forgot-password',
         '/auth/reset-password'
     ];
 
@@ -43,36 +45,31 @@ export const createAxiosInstance = (baseUrl: string): AxiosInstance => {
         failedQueue = [];
     };
 
-    // Refresh token function
-    const refreshTokens = async (): Promise<{ accessToken: string; refreshToken: string } | null> => {
+    // Refresh token function - the refresh token itself lives in an httpOnly cookie,
+    // sent automatically by the browser; we never read or store it in JS.
+    const refreshTokens = async (): Promise<{ accessToken: string } | null> => {
         try {
-            const refreshToken = getItemFromStorage({ key: "refreshToken" });
-
-            if (!refreshToken) {
-                throw new Error("No refresh token available");
-            }
-
             // Call refresh token API
-            const response = await axios.post(`${baseUrl}/auth/refresh-token`, {
-                refreshToken
-            });
+            const response = await axios.post(
+                `${baseUrl}/auth/refresh-token`,
+                {},
+                { withCredentials: true }
+            );
 
-            const { accessToken, refreshToken: newRefreshToken } = response.data.data;
+            const { accessToken } = response.data.data;
 
-            // Save new tokens
+            // Save new access token
             setItemInStorage({ key: "accessToken", value: accessToken });
-            setItemInStorage({ key: "refreshToken", value: newRefreshToken });
 
             // Reset token expiry time to recalculate
             tokenExpTimeInSeconds = 0;
 
-            return { accessToken, refreshToken: newRefreshToken };
+            return { accessToken };
         } catch (error) {
             console.error("Token refresh failed:", error);
 
             // Clear all auth data and redirect to login
             removeItemFromStorage({ key: "accessToken" });
-            removeItemFromStorage({ key: "refreshToken" });
             removeItemFromStorage({ key: "user" });
             removeItemFromStorage({ key: "userRole" });
 

--- a/src/state/services/endpoints/auth.ts
+++ b/src/state/services/endpoints/auth.ts
@@ -1,6 +1,14 @@
 import { api } from "../../../api";
 import { apiInstance } from "../api-instance";
-import { LoginRequest, LoginResponse } from "../../../types/auth-types";
+import {
+    LoginRequest,
+    LoginResponse,
+    LogoutResponse,
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
+    ResetPasswordRequest,
+    ResetPasswordResponse,
+} from "../../../types/auth-types";
 
 export const authApiService = apiInstance.injectEndpoints({
     endpoints: (build) => ({
@@ -12,10 +20,39 @@ export const authApiService = apiInstance.injectEndpoints({
                     data: credentials,
                 };
             },
-        }),        
+        }),
+        logout: build.mutation<LogoutResponse, void>({
+            query: () => {
+                return {
+                    url: api.auth.logout(),
+                    method: "POST",
+                };
+            },
+        }),
+        forgotPassword: build.mutation<ForgotPasswordResponse, ForgotPasswordRequest>({
+            query: (data) => {
+                return {
+                    url: api.auth.forgotPassword(),
+                    method: "POST",
+                    data,
+                };
+            },
+        }),
+        resetPassword: build.mutation<ResetPasswordResponse, ResetPasswordRequest>({
+            query: (data) => {
+                return {
+                    url: api.auth.resetPassword(),
+                    method: "POST",
+                    data,
+                };
+            },
+        }),
     }),
 });
 
 export const {
-    useLoginMutation,    
+    useLoginMutation,
+    useLogoutMutation,
+    useForgotPasswordMutation,
+    useResetPasswordMutation,
 } = authApiService;

--- a/src/types/auth-types.ts
+++ b/src/types/auth-types.ts
@@ -16,7 +16,31 @@ export interface LoginResponse {
         };
         tokens: {
             accessToken: string;
-            refreshToken: string;
         }
     };
+}
+
+export interface LogoutResponse {
+    success: boolean;
+    message: string;
+}
+
+export interface ForgotPasswordRequest {
+    email: string;
+}
+
+export interface ForgotPasswordResponse {
+    success: boolean;
+    message: string;
+}
+
+export interface ResetPasswordRequest {
+    token: string;
+    newPassword: string;
+    confirmPassword: string;
+}
+
+export interface ResetPasswordResponse {
+    success: boolean;
+    message: string;
 }

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,9 +1,0 @@
-import { clearStorage } from "./storage";
-import { NavigateFunction } from "react-router-dom";
-
-// Handles user logout by clearing all stored data and redirecting to login
-export const logout = (navigate: NavigateFunction) => {
-    clearStorage();
-
-    navigate("/login", { replace: true });
-};


### PR DESCRIPTION
Adds forgot-password and reset-password pages, Formik validation schemas, and API mutations (forgotPassword, resetPassword, logout). Refactors logout to a useLogout hook and removes utils/logout. Adjusts axios instance to useCredentials and treat refresh token as httpOnly cookie (no JS storage). Simplifies auth guards to check only accessToken, updates login to stop storing refreshToken and adds a Forgot Password link. Updates auth types and routes to wire the new pages.