### PR TITLE
Add student & faculty create/edit flows and APIs

### DIFF
--- a/src/api/academics.api.ts
+++ b/src/api/academics.api.ts
@@ -8,4 +8,5 @@ export const academics = {
     addDepartmentToBatchCourse: (batchCourseId: string) => `/admin/batch-courses/${batchCourseId}/departments`,
     createBatch: () => `/admin/batches`,
     getCoursesWithDepartments: () => "/admin/courses-with-departments",
+    getAllDepartments: () => "/admin/departments",
 };

--- a/src/api/faculty.api.ts
+++ b/src/api/faculty.api.ts
@@ -1,4 +1,7 @@
 export const faculty = {
     getAllFaculty: () => "/admin/faculty",
     getFacultyById: (id: string) => `/admin/faculty/${id}`,
+    createFaculty: () => "/admin/faculty",
+    updateFaculty: (id: string) => `/admin/faculty/${id}`,
+    deleteFaculty: (id: string) => `/admin/faculty/${id}`,
 };

--- a/src/api/students.api.ts
+++ b/src/api/students.api.ts
@@ -1,4 +1,7 @@
 export const students = {
     getAllStudents: () => "/admin/students",
     getStudentById: (id: string) => `/admin/students/${id}`,
+    createStudent: () => "/admin/students",
+    updateStudent: (id: string) => `/admin/students/${id}`,
+    deleteStudent: (id: string) => `/admin/students/${id}`,
 };

--- a/src/common/form-sections/AddressFields.tsx
+++ b/src/common/form-sections/AddressFields.tsx
@@ -1,0 +1,86 @@
+import InputField from "../ui/Input";
+
+interface AddressFieldsProps {
+    prefix: string;
+    title: string;
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+}
+
+const AddressFields = ({ prefix, title, values, errors, touched, handleChange, handleBlur }: AddressFieldsProps) => {
+    const address = values?.[prefix] || {};
+    const addressErrors = errors?.[prefix] || {};
+    const addressTouched = touched?.[prefix] || {};
+
+    return (
+        <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-textSecondary">{title}</h4>
+            <InputField
+                id={`${prefix}.addressLine1`}
+                name={`${prefix}.addressLine1`}
+                label="Address Line 1"
+                placeholder="House/Flat No., Street"
+                value={address.addressLine1}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={addressErrors.addressLine1}
+                touched={addressTouched.addressLine1}
+                required
+            />
+            <InputField
+                id={`${prefix}.addressLine2`}
+                name={`${prefix}.addressLine2`}
+                label="Address Line 2"
+                placeholder="Locality, Landmark (optional)"
+                value={address.addressLine2}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={addressErrors.addressLine2}
+                touched={addressTouched.addressLine2}
+            />
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <InputField
+                    id={`${prefix}.city`}
+                    name={`${prefix}.city`}
+                    label="City"
+                    placeholder="City"
+                    value={address.city}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={addressErrors.city}
+                    touched={addressTouched.city}
+                    required
+                />
+                <InputField
+                    id={`${prefix}.state`}
+                    name={`${prefix}.state`}
+                    label="State"
+                    placeholder="State"
+                    value={address.state}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={addressErrors.state}
+                    touched={addressTouched.state}
+                    required
+                />
+                <InputField
+                    id={`${prefix}.pincode`}
+                    name={`${prefix}.pincode`}
+                    label="Pincode"
+                    placeholder="6-digit pincode"
+                    value={address.pincode}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={addressErrors.pincode}
+                    touched={addressTouched.pincode}
+                    required
+                />
+            </div>
+        </div>
+    );
+};
+
+export default AddressFields;

--- a/src/common/form-sections/AddressSection.tsx
+++ b/src/common/form-sections/AddressSection.tsx
@@ -1,0 +1,50 @@
+import AddressFields from "./AddressFields";
+
+interface AddressSectionProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const AddressSection = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: AddressSectionProps) => {
+    return (
+        <div className="space-y-6">
+            <AddressFields
+                prefix="currentAddress"
+                title="Current Address"
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+            />
+
+            <label className="flex items-center gap-2 text-sm text-textSecondary cursor-pointer">
+                <input
+                    type="checkbox"
+                    checked={!!values.sameAsCurrent}
+                    onChange={(e) => setFieldValue("sameAsCurrent", e.target.checked)}
+                    className="h-4 w-4 rounded border-borderLight"
+                />
+                Permanent address is the same as current address
+            </label>
+
+            {!values.sameAsCurrent && (
+                <AddressFields
+                    prefix="permanentAddress"
+                    title="Permanent Address"
+                    values={values}
+                    errors={errors}
+                    touched={touched}
+                    handleChange={handleChange}
+                    handleBlur={handleBlur}
+                />
+            )}
+        </div>
+    );
+};
+
+export default AddressSection;

--- a/src/common/form-sections/EmergencyContactFields.tsx
+++ b/src/common/form-sections/EmergencyContactFields.tsx
@@ -1,0 +1,65 @@
+import InputField from "../ui/Input";
+import Select from "../ui/Select";
+import { RelationType } from "../../utils/enum";
+
+interface EmergencyContactFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const relationOptions = Object.values(RelationType).map((value) => ({ value, label: value }));
+
+const EmergencyContactFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: EmergencyContactFieldsProps) => {
+    const contact = values?.emergencyContact || {};
+    const contactErrors = errors?.emergencyContact || {};
+    const contactTouched = touched?.emergencyContact || {};
+
+    return (
+        <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-textSecondary">Emergency Contact</h4>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <InputField
+                    id="emergencyContact.name"
+                    name="emergencyContact.name"
+                    label="Name"
+                    placeholder="Contact name"
+                    value={contact.name}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={contactErrors.name}
+                    touched={contactTouched.name}
+                    required
+                />
+                <Select
+                    id="emergencyContact.relation"
+                    name="emergencyContact.relation"
+                    label="Relation"
+                    options={relationOptions}
+                    value={contact.relation}
+                    onChange={(value) => setFieldValue("emergencyContact.relation", value)}
+                    error={contactErrors.relation}
+                    touched={contactTouched.relation}
+                    required
+                />
+                <InputField
+                    id="emergencyContact.phoneNumber"
+                    name="emergencyContact.phoneNumber"
+                    label="Phone Number"
+                    placeholder="+91XXXXXXXXXX"
+                    value={contact.phoneNumber}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={contactErrors.phoneNumber}
+                    touched={contactTouched.phoneNumber}
+                    required
+                />
+            </div>
+        </div>
+    );
+};
+
+export default EmergencyContactFields;

--- a/src/common/form-sections/shared.schema.ts
+++ b/src/common/form-sections/shared.schema.ts
@@ -1,0 +1,21 @@
+import * as Yup from 'yup';
+import { RelationType } from '../../utils/enum';
+
+const phoneRegex = /^\+91\d{10}$/;
+const pincodeRegex = /^\d{6}$/;
+
+export const emergencyContactSchema = Yup.object({
+    name: Yup.string().required('Name is required').max(50),
+    relation: Yup.string().oneOf(Object.values(RelationType)).required('Relation is required'),
+    phoneNumber: Yup.string().matches(phoneRegex, 'Must start with +91 and contain 10 digits').required('Phone number is required'),
+});
+
+export const addressSchema = Yup.object({
+    addressLine1: Yup.string().required('Address line 1 is required'),
+    addressLine2: Yup.string(),
+    city: Yup.string().required('City is required'),
+    state: Yup.string().required('State is required'),
+    pincode: Yup.string().matches(pincodeRegex, 'Pincode must be a 6-digit number').required('Pincode is required'),
+});
+
+export const phoneValidator = Yup.string().matches(phoneRegex, 'Must start with +91 and contain 10 digits');

--- a/src/common/ui/Table.tsx
+++ b/src/common/ui/Table.tsx
@@ -80,7 +80,7 @@ export function Table<TData, TValue>({
 
                 {/* Table Section - Show Skeleton when Loading */}
                 {isLoading ? (
-                    <div className="overflow-hidden border border-borderLight border-t">
+                    <div className="overflow-x-auto border border-borderLight border-t">
                         <table className="w-full border-collapse">
                             <thead className="bg-bgSecondary">
                                 <tr>
@@ -108,7 +108,7 @@ export function Table<TData, TValue>({
                         </table>
                     </div>
                 ) : (
-                    <div className="overflow-hidden border border-borderLight border-t">
+                    <div className="overflow-x-auto border border-borderLight border-t">
                         <table className="w-full border-collapse">
                             <thead className="bg-bgSecondary">
                                 <tr>

--- a/src/features/super-admin/faculties/components/FacultyContactFields.tsx
+++ b/src/features/super-admin/faculties/components/FacultyContactFields.tsx
@@ -1,0 +1,76 @@
+import InputField from "../../../../common/ui/Input";
+import EmergencyContactFields from "../../../../common/form-sections/EmergencyContactFields";
+
+interface FacultyContactFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+    facultyEmail?: string;
+}
+
+const FacultyContactFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue, facultyEmail }: FacultyContactFieldsProps) => {
+    return (
+        <div className="space-y-4">
+            {facultyEmail && (
+                <InputField
+                    id="facultyEmail"
+                    name="facultyEmail"
+                    label="Faculty Email (auto-generated, read-only)"
+                    value={facultyEmail}
+                    disabled
+                />
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="personalEmail"
+                    name="personalEmail"
+                    type="email"
+                    label="Personal Email"
+                    placeholder="Personal email address"
+                    value={values.personalEmail}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.personalEmail}
+                    touched={touched.personalEmail}
+                    required
+                />
+                <InputField
+                    id="phoneNumber"
+                    name="phoneNumber"
+                    label="Phone Number"
+                    placeholder="+91XXXXXXXXXX"
+                    value={values.phoneNumber}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.phoneNumber}
+                    touched={touched.phoneNumber}
+                    required
+                />
+            </div>
+            <InputField
+                id="alternatePhoneNumber"
+                name="alternatePhoneNumber"
+                label="Alternate Phone Number"
+                placeholder="+91XXXXXXXXXX (optional)"
+                value={values.alternatePhoneNumber}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.alternatePhoneNumber}
+                touched={touched.alternatePhoneNumber}
+            />
+            <EmergencyContactFields
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+                setFieldValue={setFieldValue}
+            />
+        </div>
+    );
+};
+
+export default FacultyContactFields;

--- a/src/features/super-admin/faculties/components/FacultyEducationHistoryFields.tsx
+++ b/src/features/super-admin/faculties/components/FacultyEducationHistoryFields.tsx
@@ -1,0 +1,151 @@
+import { FieldArray } from "formik";
+import { Plus, Trash2 } from "lucide-react";
+import Button from "../../../../common/ui/Button";
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { EducationLevel } from "../../../../utils/enum";
+
+interface FacultyEducationHistoryFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const emptyEducationRecord = {
+    level: "",
+    qualification: "",
+    boardOrUniversity: "",
+    institutionName: "",
+    yearOfPassing: "",
+    percentageOrCGPA: "",
+    specialization: "",
+};
+
+const levelOptions = Object.values(EducationLevel).map((value) => ({ value, label: value }));
+
+const FacultyEducationHistoryFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: FacultyEducationHistoryFieldsProps) => {
+    const educationHistory = values.educationHistory || [];
+
+    return (
+        <FieldArray name="educationHistory">
+            {({ push, remove }) => (
+                <div className="space-y-6">
+                    {educationHistory.map((_: any, index: number) => {
+                        const itemErrors = (errors.educationHistory?.[index] as any) || {};
+                        const itemTouched = (touched.educationHistory?.[index] as any) || {};
+
+                        return (
+                            <div key={index} className="p-4 border border-borderLight rounded-lg space-y-4">
+                                <div className="flex items-center justify-between">
+                                    <h5 className="text-sm font-semibold text-textSecondary">Education Record {index + 1}</h5>
+                                    {educationHistory.length > 1 && (
+                                        <button
+                                            type="button"
+                                            onClick={() => remove(index)}
+                                            className="text-red-600 hover:text-red-700 cursor-pointer"
+                                        >
+                                            <Trash2 className="h-4 w-4" />
+                                        </button>
+                                    )}
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <Select
+                                        id={`educationHistory.${index}.level`}
+                                        name={`educationHistory.${index}.level`}
+                                        label="Level"
+                                        options={levelOptions}
+                                        value={educationHistory[index].level}
+                                        onChange={(value) => setFieldValue(`educationHistory.${index}.level`, value)}
+                                        error={itemErrors.level}
+                                        touched={itemTouched.level}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.qualification`}
+                                        name={`educationHistory.${index}.qualification`}
+                                        label="Qualification"
+                                        placeholder="e.g. PhD"
+                                        value={educationHistory[index].qualification}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.qualification}
+                                        touched={itemTouched.qualification}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.boardOrUniversity`}
+                                        name={`educationHistory.${index}.boardOrUniversity`}
+                                        label="Board / University"
+                                        value={educationHistory[index].boardOrUniversity}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.boardOrUniversity}
+                                        touched={itemTouched.boardOrUniversity}
+                                        required
+                                    />
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                                    <InputField
+                                        id={`educationHistory.${index}.institutionName`}
+                                        name={`educationHistory.${index}.institutionName`}
+                                        label="Institution Name"
+                                        value={educationHistory[index].institutionName}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.institutionName}
+                                        touched={itemTouched.institutionName}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.yearOfPassing`}
+                                        name={`educationHistory.${index}.yearOfPassing`}
+                                        type="number"
+                                        label="Year of Passing"
+                                        value={educationHistory[index].yearOfPassing}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.yearOfPassing}
+                                        touched={itemTouched.yearOfPassing}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.percentageOrCGPA`}
+                                        name={`educationHistory.${index}.percentageOrCGPA`}
+                                        type="number"
+                                        label="Percentage / CGPA"
+                                        value={educationHistory[index].percentageOrCGPA}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.percentageOrCGPA}
+                                        touched={itemTouched.percentageOrCGPA}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.specialization`}
+                                        name={`educationHistory.${index}.specialization`}
+                                        label="Specialization"
+                                        placeholder="Optional"
+                                        value={educationHistory[index].specialization}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.specialization}
+                                        touched={itemTouched.specialization}
+                                    />
+                                </div>
+                            </div>
+                        );
+                    })}
+
+                    <Button type="button" variant="outline" size="sm" icon={Plus} onClick={() => push({ ...emptyEducationRecord })}>
+                        Add Education Record
+                    </Button>
+                </div>
+            )}
+        </FieldArray>
+    );
+};
+
+export default FacultyEducationHistoryFields;

--- a/src/features/super-admin/faculties/components/FacultyEmploymentFields.tsx
+++ b/src/features/super-admin/faculties/components/FacultyEmploymentFields.tsx
@@ -1,0 +1,115 @@
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { FacultyDesignation, EmploymentType, HighestQualification } from "../../../../utils/enum";
+import { useGetAllDepartmentsQuery } from "../../../../state/services/endpoints/academics";
+
+interface FacultyEmploymentFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const designationOptions = Object.values(FacultyDesignation).map((value) => ({ value, label: value }));
+const employmentTypeOptions = Object.values(EmploymentType).map((value) => ({ value, label: value }));
+const highestQualificationOptions = Object.values(HighestQualification).map((value) => ({ value, label: value }));
+
+const FacultyEmploymentFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: FacultyEmploymentFieldsProps) => {
+    const { data: departmentsData, isFetching: isDepartmentsLoading } = useGetAllDepartmentsQuery();
+    const departmentOptions = (departmentsData?.data || []).map((d) => ({ value: d._id, label: d.deptName }));
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="employeeId"
+                    name="employeeId"
+                    label="Employee ID"
+                    placeholder="e.g. FAC2024001"
+                    value={values.employeeId}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.employeeId}
+                    touched={touched.employeeId}
+                    required
+                />
+                <Select
+                    id="departmentId"
+                    name="departmentId"
+                    label="Department"
+                    options={departmentOptions}
+                    value={values.departmentId}
+                    loading={isDepartmentsLoading}
+                    onChange={(value) => setFieldValue("departmentId", value)}
+                    error={errors.departmentId}
+                    touched={touched.departmentId}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Select
+                    id="designation"
+                    name="designation"
+                    label="Designation"
+                    options={designationOptions}
+                    value={values.designation}
+                    onChange={(value) => setFieldValue("designation", value)}
+                    error={errors.designation}
+                    touched={touched.designation}
+                    required
+                />
+                <Select
+                    id="employmentType"
+                    name="employmentType"
+                    label="Employment Type"
+                    options={employmentTypeOptions}
+                    value={values.employmentType}
+                    onChange={(value) => setFieldValue("employmentType", value)}
+                    error={errors.employmentType}
+                    touched={touched.employmentType}
+                    required
+                />
+                <InputField
+                    id="totalExperienceYears"
+                    name="totalExperienceYears"
+                    type="number"
+                    label="Total Experience (years)"
+                    value={values.totalExperienceYears}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.totalExperienceYears}
+                    touched={touched.totalExperienceYears}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Select
+                    id="highestQualification"
+                    name="highestQualification"
+                    label="Highest Qualification"
+                    options={highestQualificationOptions}
+                    value={values.highestQualification}
+                    onChange={(value) => setFieldValue("highestQualification", value)}
+                    error={errors.highestQualification}
+                    touched={touched.highestQualification}
+                    required
+                />
+                <InputField
+                    id="remarks"
+                    name="remarks"
+                    label="Remarks"
+                    placeholder="Optional"
+                    value={values.remarks}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.remarks}
+                    touched={touched.remarks}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default FacultyEmploymentFields;

--- a/src/features/super-admin/faculties/components/FacultyPersonalFields.tsx
+++ b/src/features/super-admin/faculties/components/FacultyPersonalFields.tsx
@@ -1,0 +1,112 @@
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { Gender, MaritalStatus } from "../../../../utils/enum";
+
+interface FacultyPersonalFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const genderOptions = Object.values(Gender).map((value) => ({ value, label: value }));
+const maritalStatusOptions = Object.values(MaritalStatus).map((value) => ({ value, label: value }));
+
+const FacultyPersonalFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: FacultyPersonalFieldsProps) => {
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="firstName"
+                    name="firstName"
+                    label="First Name"
+                    placeholder="First name"
+                    value={values.firstName}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.firstName}
+                    touched={touched.firstName}
+                    required
+                />
+                <InputField
+                    id="lastName"
+                    name="lastName"
+                    label="Last Name"
+                    placeholder="Last name"
+                    value={values.lastName}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.lastName}
+                    touched={touched.lastName}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Select
+                    id="gender"
+                    name="gender"
+                    label="Gender"
+                    options={genderOptions}
+                    value={values.gender}
+                    onChange={(value) => setFieldValue("gender", value)}
+                    error={errors.gender}
+                    touched={touched.gender}
+                    required
+                />
+                <InputField
+                    id="dateOfBirth"
+                    name="dateOfBirth"
+                    type="text"
+                    label="Date of Birth"
+                    placeholder="YYYY-MM-DD"
+                    value={values.dateOfBirth}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.dateOfBirth}
+                    touched={touched.dateOfBirth}
+                    required
+                />
+                <Select
+                    id="maritalStatus"
+                    name="maritalStatus"
+                    label="Marital Status"
+                    options={maritalStatusOptions}
+                    value={values.maritalStatus}
+                    onChange={(value) => setFieldValue("maritalStatus", value)}
+                    error={errors.maritalStatus}
+                    touched={touched.maritalStatus}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="religion"
+                    name="religion"
+                    label="Religion"
+                    placeholder="Religion (optional)"
+                    value={values.religion}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.religion}
+                    touched={touched.religion}
+                />
+                <InputField
+                    id="profilePhotoUrl"
+                    name="profilePhotoUrl"
+                    label="Profile Photo URL"
+                    placeholder="https://..."
+                    value={values.profilePhotoUrl}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.profilePhotoUrl}
+                    touched={touched.profilePhotoUrl}
+                    required
+                />
+            </div>
+        </div>
+    );
+};
+
+export default FacultyPersonalFields;

--- a/src/features/super-admin/faculties/components/FacultyWorkExperienceFields.tsx
+++ b/src/features/super-admin/faculties/components/FacultyWorkExperienceFields.tsx
@@ -1,0 +1,175 @@
+import { FieldArray } from "formik";
+import { Plus, Trash2 } from "lucide-react";
+import Button from "../../../../common/ui/Button";
+import InputField from "../../../../common/ui/Input";
+
+interface FacultyWorkExperienceFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const emptyWorkExperience = {
+    organization: "",
+    role: "",
+    department: "",
+    fromDate: "",
+    toDate: "",
+    experienceYears: "",
+    jobDescription: "",
+    reasonForLeaving: "",
+    isCurrent: false,
+};
+
+const FacultyWorkExperienceFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: FacultyWorkExperienceFieldsProps) => {
+    const workExperience = values.workExperience || [];
+
+    return (
+        <FieldArray name="workExperience">
+            {({ push, remove }) => (
+                <div className="space-y-6">
+                    {workExperience.length === 0 && (
+                        <p className="text-sm text-textTertiary">No prior work experience added (optional).</p>
+                    )}
+
+                    {workExperience.map((_: any, index: number) => {
+                        const itemErrors = (errors.workExperience?.[index] as any) || {};
+                        const itemTouched = (touched.workExperience?.[index] as any) || {};
+
+                        return (
+                            <div key={index} className="p-4 border border-borderLight rounded-lg space-y-4">
+                                <div className="flex items-center justify-between">
+                                    <h5 className="text-sm font-semibold text-textSecondary">Work Experience {index + 1}</h5>
+                                    <button
+                                        type="button"
+                                        onClick={() => remove(index)}
+                                        className="text-red-600 hover:text-red-700 cursor-pointer"
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </button>
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <InputField
+                                        id={`workExperience.${index}.organization`}
+                                        name={`workExperience.${index}.organization`}
+                                        label="Organization"
+                                        value={workExperience[index].organization}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.organization}
+                                        touched={itemTouched.organization}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`workExperience.${index}.role`}
+                                        name={`workExperience.${index}.role`}
+                                        label="Role"
+                                        value={workExperience[index].role}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.role}
+                                        touched={itemTouched.role}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`workExperience.${index}.department`}
+                                        name={`workExperience.${index}.department`}
+                                        label="Department"
+                                        placeholder="Optional"
+                                        value={workExperience[index].department}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.department}
+                                        touched={itemTouched.department}
+                                    />
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <InputField
+                                        id={`workExperience.${index}.fromDate`}
+                                        name={`workExperience.${index}.fromDate`}
+                                        type="text"
+                                        label="From Date"
+                                        placeholder="YYYY-MM-DD"
+                                        value={workExperience[index].fromDate}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.fromDate}
+                                        touched={itemTouched.fromDate}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`workExperience.${index}.toDate`}
+                                        name={`workExperience.${index}.toDate`}
+                                        type="text"
+                                        label="To Date"
+                                        placeholder="YYYY-MM-DD"
+                                        value={workExperience[index].toDate}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.toDate}
+                                        touched={itemTouched.toDate}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`workExperience.${index}.experienceYears`}
+                                        name={`workExperience.${index}.experienceYears`}
+                                        type="number"
+                                        label="Experience (years)"
+                                        value={workExperience[index].experienceYears}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.experienceYears}
+                                        touched={itemTouched.experienceYears}
+                                        required
+                                    />
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <InputField
+                                        id={`workExperience.${index}.jobDescription`}
+                                        name={`workExperience.${index}.jobDescription`}
+                                        label="Job Description"
+                                        placeholder="Optional"
+                                        value={workExperience[index].jobDescription}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.jobDescription}
+                                        touched={itemTouched.jobDescription}
+                                    />
+                                    <InputField
+                                        id={`workExperience.${index}.reasonForLeaving`}
+                                        name={`workExperience.${index}.reasonForLeaving`}
+                                        label="Reason for Leaving"
+                                        placeholder="Optional"
+                                        value={workExperience[index].reasonForLeaving}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.reasonForLeaving}
+                                        touched={itemTouched.reasonForLeaving}
+                                    />
+                                </div>
+                                <label className="flex items-center gap-2 text-sm text-textSecondary cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        checked={!!workExperience[index].isCurrent}
+                                        onChange={(e) => setFieldValue(`workExperience.${index}.isCurrent`, e.target.checked)}
+                                        className="h-4 w-4 rounded border-borderLight"
+                                    />
+                                    This is the current organization
+                                </label>
+                            </div>
+                        );
+                    })}
+
+                    <Button type="button" variant="outline" size="sm" icon={Plus} onClick={() => push({ ...emptyWorkExperience })}>
+                        Add Work Experience
+                    </Button>
+                </div>
+            )}
+        </FieldArray>
+    );
+};
+
+export default FacultyWorkExperienceFields;

--- a/src/features/super-admin/faculties/formik/create-faculty.schema.ts
+++ b/src/features/super-admin/faculties/formik/create-faculty.schema.ts
@@ -1,0 +1,59 @@
+import * as Yup from 'yup';
+import { Gender, MaritalStatus, EmploymentType, FacultyDesignation, HighestQualification, EducationLevel } from '../../../../utils/enum';
+import { addressSchema, emergencyContactSchema, phoneValidator } from '../../../../common/form-sections/shared.schema';
+
+const educationHistorySchema = Yup.object({
+    level: Yup.string().oneOf(Object.values(EducationLevel)).required('Level is required'),
+    qualification: Yup.string().required('Qualification is required').max(50),
+    boardOrUniversity: Yup.string().required('Board/University is required').max(100),
+    institutionName: Yup.string().required('Institution name is required').max(100),
+    yearOfPassing: Yup.number().typeError('Must be a number').required('Year of passing is required'),
+    percentageOrCGPA: Yup.number().typeError('Must be a number').required('Percentage/CGPA is required'),
+    specialization: Yup.string().max(100),
+});
+
+const workExperienceSchema = Yup.object({
+    organization: Yup.string().required('Organization is required').max(100),
+    role: Yup.string().required('Role is required').max(50),
+    department: Yup.string().max(50),
+    fromDate: Yup.string().required('From date is required'),
+    toDate: Yup.string().required('To date is required'),
+    experienceYears: Yup.number().typeError('Must be a number').required('Experience is required'),
+    jobDescription: Yup.string(),
+    reasonForLeaving: Yup.string(),
+    isCurrent: Yup.boolean(),
+});
+
+export const createFacultyValidationSchema = Yup.object({
+    firstName: Yup.string().required('First name is required').max(30),
+    lastName: Yup.string().required('Last name is required').max(30),
+    gender: Yup.string().oneOf(Object.values(Gender)).required('Gender is required'),
+    dateOfBirth: Yup.string().required('Date of birth is required'),
+    maritalStatus: Yup.string().oneOf(Object.values(MaritalStatus)).required('Marital status is required'),
+    profilePhotoUrl: Yup.string().required('Profile photo URL is required'),
+    religion: Yup.string().max(30),
+
+    personalEmail: Yup.string().email('Must be a valid email').required('Personal email is required'),
+    phoneNumber: phoneValidator.required('Phone number is required'),
+    alternatePhoneNumber: phoneValidator,
+    emergencyContact: emergencyContactSchema,
+
+    currentAddress: addressSchema,
+    sameAsCurrent: Yup.boolean(),
+    permanentAddress: Yup.object().when('sameAsCurrent', {
+        is: false,
+        then: () => addressSchema,
+        otherwise: (schema) => schema.notRequired(),
+    }),
+
+    employeeId: Yup.string().required('Employee ID is required'),
+    designation: Yup.string().oneOf(Object.values(FacultyDesignation)).required('Designation is required'),
+    departmentId: Yup.string().required('Department is required'),
+    employmentType: Yup.string().oneOf(Object.values(EmploymentType)).required('Employment type is required'),
+    totalExperienceYears: Yup.number().typeError('Must be a number').required('Total experience is required').min(0),
+    highestQualification: Yup.string().oneOf(Object.values(HighestQualification)).required('Highest qualification is required'),
+    remarks: Yup.string(),
+
+    educationHistory: Yup.array().of(educationHistorySchema).min(1, 'At least one education record is required'),
+    workExperience: Yup.array().of(workExperienceSchema),
+});

--- a/src/features/super-admin/faculties/formik/edit-faculty.schema.ts
+++ b/src/features/super-admin/faculties/formik/edit-faculty.schema.ts
@@ -1,0 +1,51 @@
+import * as Yup from 'yup';
+import { Gender, MaritalStatus, EducationLevel } from '../../../../utils/enum';
+import { addressSchema, emergencyContactSchema, phoneValidator } from '../../../../common/form-sections/shared.schema';
+
+const educationHistorySchema = Yup.object({
+    level: Yup.string().oneOf(Object.values(EducationLevel)).required('Level is required'),
+    qualification: Yup.string().required('Qualification is required').max(50),
+    boardOrUniversity: Yup.string().required('Board/University is required').max(100),
+    institutionName: Yup.string().required('Institution name is required').max(100),
+    yearOfPassing: Yup.number().typeError('Must be a number').required('Year of passing is required'),
+    percentageOrCGPA: Yup.number().typeError('Must be a number').required('Percentage/CGPA is required'),
+    specialization: Yup.string().max(100),
+});
+
+const workExperienceSchema = Yup.object({
+    organization: Yup.string().required('Organization is required').max(100),
+    role: Yup.string().required('Role is required').max(50),
+    department: Yup.string().max(50),
+    fromDate: Yup.string().required('From date is required'),
+    toDate: Yup.string().required('To date is required'),
+    experienceYears: Yup.number().typeError('Must be a number').required('Experience is required'),
+    jobDescription: Yup.string(),
+    reasonForLeaving: Yup.string(),
+    isCurrent: Yup.boolean(),
+});
+
+export const editFacultyValidationSchema = Yup.object({
+    firstName: Yup.string().required('First name is required').max(30),
+    lastName: Yup.string().required('Last name is required').max(30),
+    gender: Yup.string().oneOf(Object.values(Gender)).required('Gender is required'),
+    dateOfBirth: Yup.string().required('Date of birth is required'),
+    maritalStatus: Yup.string().oneOf(Object.values(MaritalStatus)).required('Marital status is required'),
+    profilePhotoUrl: Yup.string().required('Profile photo URL is required'),
+    religion: Yup.string().max(30),
+
+    personalEmail: Yup.string().email('Must be a valid email').required('Personal email is required'),
+    phoneNumber: phoneValidator.required('Phone number is required'),
+    alternatePhoneNumber: phoneValidator,
+    emergencyContact: emergencyContactSchema,
+
+    currentAddress: addressSchema,
+    sameAsCurrent: Yup.boolean(),
+    permanentAddress: Yup.object().when('sameAsCurrent', {
+        is: false,
+        then: () => addressSchema,
+        otherwise: (schema) => schema.notRequired(),
+    }),
+
+    educationHistory: Yup.array().of(educationHistorySchema).min(1, 'At least one education record is required'),
+    workExperience: Yup.array().of(workExperienceSchema),
+});

--- a/src/features/super-admin/faculties/pages/CreateFacultyPage.tsx
+++ b/src/features/super-admin/faculties/pages/CreateFacultyPage.tsx
@@ -1,0 +1,121 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { useNavigate } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import { Container } from "../../../../common/ui/Container";
+import { PageHeader } from "../../../../common/ui/PageHeader";
+import { Country } from "../../../../utils/enum";
+import AddressSection from "../../../../common/form-sections/AddressSection";
+import { createFacultyValidationSchema } from "../formik/create-faculty.schema";
+import { useCreateFacultyMutation } from "../../../../state/services/endpoints/faculty";
+import FacultyPersonalFields from "../components/FacultyPersonalFields";
+import FacultyContactFields from "../components/FacultyContactFields";
+import FacultyEmploymentFields from "../components/FacultyEmploymentFields";
+import FacultyEducationHistoryFields from "../components/FacultyEducationHistoryFields";
+import FacultyWorkExperienceFields from "../components/FacultyWorkExperienceFields";
+
+const initialValues = {
+    firstName: '', lastName: '', gender: '', dateOfBirth: '', maritalStatus: '', profilePhotoUrl: '', religion: '',
+    personalEmail: '', phoneNumber: '', alternatePhoneNumber: '',
+    emergencyContact: { name: '', relation: '', phoneNumber: '' },
+    currentAddress: { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+    sameAsCurrent: true,
+    permanentAddress: { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+    employeeId: '', designation: '', departmentId: '', employmentType: '', totalExperienceYears: '', highestQualification: '', remarks: '',
+    educationHistory: [{ level: '', qualification: '', boardOrUniversity: '', institutionName: '', yearOfPassing: '', percentageOrCGPA: '', specialization: '' }],
+    workExperience: [] as any[],
+};
+
+const CreateFacultyPage = () => {
+    const navigate = useNavigate();
+    const [createFaculty, { isLoading }] = useCreateFacultyMutation();
+
+    const handleSubmit = async (values: typeof initialValues, { setSubmitting }: any) => {
+        try {
+            const payload = {
+                ...values,
+                alternatePhoneNumber: values.alternatePhoneNumber || undefined,
+                totalExperienceYears: Number(values.totalExperienceYears),
+                currentAddress: { ...values.currentAddress, country: Country.INDIA },
+                permanentAddress: values.sameAsCurrent ? undefined : { ...values.permanentAddress, country: Country.INDIA },
+                educationHistory: values.educationHistory.map((edu) => ({
+                    ...edu,
+                    yearOfPassing: Number(edu.yearOfPassing),
+                    percentageOrCGPA: Number(edu.percentageOrCGPA),
+                })),
+                workExperience: values.workExperience.map((work) => ({
+                    ...work,
+                    experienceYears: Number(work.experienceYears),
+                })),
+            };
+
+            const response = await createFaculty(payload as any).unwrap();
+            toast.success(response.message || 'Faculty created successfully');
+            navigate('/super-admin/faculties');
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to create faculty');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <PageHeader>Add Faculty</PageHeader>
+            <Container>
+                <div className="py-6">
+                    <Formik
+                        initialValues={initialValues}
+                        validationSchema={createFacultyValidationSchema}
+                        onSubmit={handleSubmit}
+                    >
+                        {({ values, errors, touched, handleChange, handleBlur, setFieldValue, isSubmitting }) => (
+                            <Form className="space-y-10">
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Personal Details</h3>
+                                    <FacultyPersonalFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Contact Information</h3>
+                                    <FacultyContactFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Address</h3>
+                                    <AddressSection values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Employment Details</h3>
+                                    <FacultyEmploymentFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Education History</h3>
+                                    <FacultyEducationHistoryFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Work Experience</h3>
+                                    <FacultyWorkExperienceFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <div className="flex justify-end gap-3 pt-4 border-t border-borderLight">
+                                    <Button type="button" variant="outline" onClick={() => navigate('/super-admin/faculties')}>
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" variant="primary" loading={isSubmitting || isLoading} disabled={isSubmitting || isLoading}>
+                                        {isSubmitting || isLoading ? '' : 'Create Faculty'}
+                                    </Button>
+                                </div>
+                            </Form>
+                        )}
+                    </Formik>
+                </div>
+            </Container>
+        </>
+    );
+};
+
+export default CreateFacultyPage;

--- a/src/features/super-admin/faculties/pages/EditFacultyPage.tsx
+++ b/src/features/super-admin/faculties/pages/EditFacultyPage.tsx
@@ -1,0 +1,179 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { useNavigate, useParams } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import { Container } from "../../../../common/ui/Container";
+import { PageHeader } from "../../../../common/ui/PageHeader";
+import { Country } from "../../../../utils/enum";
+import AddressSection from "../../../../common/form-sections/AddressSection";
+import { editFacultyValidationSchema } from "../formik/edit-faculty.schema";
+import { useGetFacultyByIdQuery, useUpdateFacultyMutation } from "../../../../state/services/endpoints/faculty";
+import FacultyPersonalFields from "../components/FacultyPersonalFields";
+import FacultyContactFields from "../components/FacultyContactFields";
+import FacultyEducationHistoryFields from "../components/FacultyEducationHistoryFields";
+import FacultyWorkExperienceFields from "../components/FacultyWorkExperienceFields";
+
+const EditFacultyPage = () => {
+    const navigate = useNavigate();
+    const { id } = useParams<{ id: string }>();
+    const { data, isLoading: isLoadingFaculty } = useGetFacultyByIdQuery(id as string, { skip: !id });
+    const [updateFaculty, { isLoading: isUpdating }] = useUpdateFacultyMutation();
+
+    if (isLoadingFaculty || !data?.data) {
+        return (
+            <>
+                <PageHeader>Edit Faculty</PageHeader>
+                <Container>
+                    <div className="py-6 text-textSecondary">Loading faculty details...</div>
+                </Container>
+            </>
+        );
+    }
+
+    const faculty = data.data;
+
+    const initialValues = {
+        firstName: faculty.personalDetails.firstName,
+        lastName: faculty.personalDetails.lastName,
+        gender: faculty.personalDetails.gender,
+        dateOfBirth: faculty.personalDetails.dateOfBirth,
+        maritalStatus: faculty.personalDetails.maritalStatus,
+        profilePhotoUrl: faculty.personalDetails.profilePhotoUrl,
+        religion: faculty.personalDetails.religion || '',
+
+        personalEmail: faculty.contactDetails.personalEmail,
+        phoneNumber: faculty.contactDetails.phoneNumber,
+        alternatePhoneNumber: faculty.contactDetails.alternatePhoneNumber || '',
+        emergencyContact: { ...faculty.contactDetails.emergencyContact },
+
+        currentAddress: { ...faculty.addressDetails.currentAddress },
+        sameAsCurrent: faculty.addressDetails.sameAsCurrent,
+        permanentAddress: faculty.addressDetails.permanentAddress
+            ? { ...faculty.addressDetails.permanentAddress }
+            : { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+
+        educationHistory: faculty.educationHistory.length > 0
+            ? faculty.educationHistory.map((edu) => ({
+                level: edu.level,
+                qualification: edu.qualification,
+                boardOrUniversity: edu.boardOrUniversity,
+                institutionName: edu.institutionName,
+                yearOfPassing: edu.yearOfPassing,
+                percentageOrCGPA: edu.percentageOrCGPA,
+                specialization: edu.specialization || '',
+            }))
+            : [{ level: '', qualification: '', boardOrUniversity: '', institutionName: '', yearOfPassing: '', percentageOrCGPA: '', specialization: '' }],
+
+        workExperience: faculty.workExperience.map((work) => ({
+            organization: work.organization,
+            role: work.role,
+            department: work.department || '',
+            fromDate: work.fromDate,
+            toDate: work.toDate,
+            experienceYears: work.experienceYears,
+            jobDescription: work.jobDescription || '',
+            reasonForLeaving: work.reasonForLeaving || '',
+            isCurrent: work.isCurrent,
+        })),
+    };
+
+    const handleSubmit = async (values: typeof initialValues, { setSubmitting }: any) => {
+        try {
+            const payload = {
+                ...values,
+                alternatePhoneNumber: values.alternatePhoneNumber || undefined,
+                currentAddress: { ...values.currentAddress, country: Country.INDIA },
+                permanentAddress: values.sameAsCurrent ? undefined : { ...values.permanentAddress, country: Country.INDIA },
+                educationHistory: values.educationHistory.map((edu) => ({
+                    ...edu,
+                    yearOfPassing: Number(edu.yearOfPassing),
+                    percentageOrCGPA: Number(edu.percentageOrCGPA),
+                })),
+                workExperience: values.workExperience.map((work) => ({
+                    ...work,
+                    experienceYears: Number(work.experienceYears),
+                })),
+            };
+
+            const response = await updateFaculty({ id: id as string, data: payload as any }).unwrap();
+            toast.success(response.message || 'Faculty updated successfully');
+            navigate(`/super-admin/faculties/${id}`);
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to update faculty');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <PageHeader>Edit Faculty</PageHeader>
+            <Container>
+                <div className="py-6 space-y-10">
+                    <section className="space-y-2">
+                        <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Employment Details (read-only)</h3>
+                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                            <div><span className="text-textTertiary">Employee ID:</span> <span className="text-textPrimary">{faculty.employmentDetails.employeeId}</span></div>
+                            <div><span className="text-textTertiary">Designation:</span> <span className="text-textPrimary">{faculty.employmentDetails.designation}</span></div>
+                            <div><span className="text-textTertiary">Department:</span> <span className="text-textPrimary">{faculty.employmentDetails.departmentName}</span></div>
+                            <div><span className="text-textTertiary">Employment Type:</span> <span className="text-textPrimary">{faculty.employmentDetails.employmentType}</span></div>
+                            <div><span className="text-textTertiary">Experience (years):</span> <span className="text-textPrimary">{faculty.employmentDetails.totalExperienceYears}</span></div>
+                            <div><span className="text-textTertiary">Highest Qualification:</span> <span className="text-textPrimary">{faculty.employmentDetails.highestQualification}</span></div>
+                            <div><span className="text-textTertiary">Status:</span> <span className="text-textPrimary">{faculty.employmentDetails.status}</span></div>
+                        </div>
+                    </section>
+
+                    <Formik
+                        initialValues={initialValues}
+                        validationSchema={editFacultyValidationSchema}
+                        onSubmit={handleSubmit}
+                        enableReinitialize
+                    >
+                        {({ values, errors, touched, handleChange, handleBlur, setFieldValue, isSubmitting }) => (
+                            <Form className="space-y-10">
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Personal Details</h3>
+                                    <FacultyPersonalFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Contact Information</h3>
+                                    <FacultyContactFields
+                                        values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue}
+                                        facultyEmail={faculty.contactDetails.facultyEmail}
+                                    />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Address</h3>
+                                    <AddressSection values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Education History</h3>
+                                    <FacultyEducationHistoryFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Work Experience</h3>
+                                    <FacultyWorkExperienceFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <div className="flex justify-end gap-3 pt-4 border-t border-borderLight">
+                                    <Button type="button" variant="outline" onClick={() => navigate(`/super-admin/faculties/${id}`)}>
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" variant="primary" loading={isSubmitting || isUpdating} disabled={isSubmitting || isUpdating}>
+                                        {isSubmitting || isUpdating ? '' : 'Save Changes'}
+                                    </Button>
+                                </div>
+                            </Form>
+                        )}
+                    </Formik>
+                </div>
+            </Container>
+        </>
+    );
+};
+
+export default EditFacultyPage;

--- a/src/features/super-admin/faculties/pages/FacultiesPage.tsx
+++ b/src/features/super-admin/faculties/pages/FacultiesPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import Modal from "../../../../common/ui/Modal";
 import Button from "../../../../common/ui/Button";
 import { Container } from "../../../../common/ui/Container";
 import { PageHeader } from "../../../../common/ui/PageHeader";
@@ -13,7 +12,6 @@ const FacultiesPage = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
     const [searchTerm, setSearchTerm] = useState("");
-    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const { data, isLoading, isFetching } = useGetAllFacultyQuery({
         page,
@@ -38,14 +36,6 @@ const FacultiesPage = () => {
     const handleRowClick = useCallback((row: FacultyData) => {
         navigate(`/super-admin/faculties/${row.id}`);
     }, [navigate]);
-
-    const handleOpenModal = useCallback(() => {
-        setIsModalOpen(true);
-    }, []);
-
-    const handleCloseModal = useCallback(() => {
-        setIsModalOpen(false);
-    }, []);
 
     const columns: ColumnDef<FacultyData, any>[] = [
         {
@@ -123,15 +113,17 @@ const FacultiesPage = () => {
     return (
         <>
             <PageHeader>Faculty</PageHeader>
-            <div className="flex justify-end">
-                <Button
-                    type="submit"
-                    variant="primary"
-                    size="md"
-                    onClick={handleOpenModal}
-                >
-                    Add Faculty
-                </Button>
+            <div className="px-6">
+                <div className="flex justify-end">
+                    <Button
+                        type="button"
+                        variant="primary"
+                        size="md"
+                        onClick={() => navigate('/super-admin/faculties/create')}
+                    >
+                        Add Faculty
+                    </Button>
+                </div>
             </div>
 
             <Container>
@@ -152,15 +144,6 @@ const FacultiesPage = () => {
                     />
                 </div>
             </Container>
-
-            <Modal
-                isOpen={isModalOpen}
-                onClose={handleCloseModal}
-                title="Add New Faculty"
-                size="md"
-            >
-                <div></div>
-            </Modal>
         </>
     );
 };

--- a/src/features/super-admin/faculties/pages/FacultyDetailPage .tsx
+++ b/src/features/super-admin/faculties/pages/FacultyDetailPage .tsx
@@ -1,16 +1,33 @@
+import toast from "react-hot-toast";
+import { useState } from "react";
+import Modal from "../../../../common/ui/Modal";
 import Button from "../../../../common/ui/Button";
 import Timeline from "../../../../common/ui/Timeline";
 import { useParams, useNavigate } from "react-router-dom";
 import { Container } from "../../../../common/ui/Container";
 import { PageHeader } from "../../../../common/ui/PageHeader";
 import FacultyDetailSkeleton from "../components/FacultyDetailSkeleton";
-import { useGetFacultyByIdQuery } from "../../../../state/services/endpoints/faculty";
+import { useGetFacultyByIdQuery, useDeleteFacultyMutation } from "../../../../state/services/endpoints/faculty";
 import { Calendar, Flag, GraduationCap, MapPin, Phone, User, Users, Briefcase } from "lucide-react";
 
 const FacultyDetailPage = () => {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const { data, isLoading, error } = useGetFacultyByIdQuery(id!);
+    const [deleteFaculty, { isLoading: isDeleting }] = useDeleteFacultyMutation();
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+    const handleDelete = async () => {
+        try {
+            const response = await deleteFaculty(id!).unwrap();
+            toast.success(response.message || 'Faculty deactivated successfully');
+            navigate("/super-admin/faculties");
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to delete faculty');
+        } finally {
+            setIsDeleteModalOpen(false);
+        }
+    };
 
     if (isLoading) {
         return (
@@ -52,7 +69,7 @@ const FacultyDetailPage = () => {
         <>
             <PageHeader>Faculty Details</PageHeader>
             <Container>
-                <div className="mb-6">
+                <div className="mb-6 flex items-center justify-between">
                     <Button
                         variant="primary"
                         size="sm"
@@ -60,6 +77,22 @@ const FacultyDetailPage = () => {
                     >
                         ← Back to Faculty
                     </Button>
+                    <div className="flex items-center gap-3">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => navigate(`/super-admin/faculties/${id}/edit`)}
+                        >
+                            Edit
+                        </Button>
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => setIsDeleteModalOpen(true)}
+                        >
+                            Delete
+                        </Button>
+                    </div>
                 </div>
 
                 <div className="space-y-6 mb-6">
@@ -375,6 +408,27 @@ const FacultyDetailPage = () => {
                     </div>
                 </div>
             </Container>
+
+            <Modal
+                isOpen={isDeleteModalOpen}
+                onClose={() => setIsDeleteModalOpen(false)}
+                title="Delete Faculty"
+                size="sm"
+            >
+                <div className="space-y-6">
+                    <p className="text-sm text-textSecondary">
+                        Are you sure you want to delete <span className="font-semibold text-textPrimary">{fullName}</span>? This will deactivate their account and they will no longer be able to log in.
+                    </p>
+                    <div className="flex justify-end gap-3">
+                        <Button variant="outline" size="sm" onClick={() => setIsDeleteModalOpen(false)}>
+                            Cancel
+                        </Button>
+                        <Button variant="danger" size="sm" loading={isDeleting} disabled={isDeleting} onClick={handleDelete}>
+                            {isDeleting ? '' : 'Delete'}
+                        </Button>
+                    </div>
+                </div>
+            </Modal>
         </>
     );
 };

--- a/src/features/super-admin/routes/superAdminRoutes.tsx
+++ b/src/features/super-admin/routes/superAdminRoutes.tsx
@@ -10,6 +10,10 @@ import SuperAdminDashboardPage from "../dashboard/pages/SuperAdminDashboardPage"
 import ExamsPage from "../exams/pages/ExamsPage";
 import StudentDetailPage from "../students/pages/StudentDetailPage";
 import FacultyDetailPage from "../faculties/pages/FacultyDetailPage ";
+import CreateStudentPage from "../students/pages/CreateStudentPage";
+import EditStudentPage from "../students/pages/EditStudentPage";
+import CreateFacultyPage from "../faculties/pages/CreateFacultyPage";
+import EditFacultyPage from "../faculties/pages/EditFacultyPage";
 
 export const superAdminRoutes: RouteObject[] = [
     {
@@ -55,10 +59,26 @@ export const superAdminRoutes: RouteObject[] = [
         ),
     },
     {
+        path: "/super-admin/students/create",
+        element: (
+            <RoleGuard allowedRoles={[UserRole.ADMIN]}>
+                <CreateStudentPage />
+            </RoleGuard>
+        ),
+    },
+    {
         path: "/super-admin/students/:id",
         element: (
             <RoleGuard allowedRoles={[UserRole.ADMIN]}>
                 <StudentDetailPage />
+            </RoleGuard>
+        ),
+    },
+    {
+        path: "/super-admin/students/:id/edit",
+        element: (
+            <RoleGuard allowedRoles={[UserRole.ADMIN]}>
+                <EditStudentPage />
             </RoleGuard>
         ),
     },
@@ -72,10 +92,26 @@ export const superAdminRoutes: RouteObject[] = [
         ),
     },
     {
+        path: "/super-admin/faculties/create",
+        element: (
+            <RoleGuard allowedRoles={[UserRole.ADMIN]}>
+                <CreateFacultyPage />
+            </RoleGuard>
+        ),
+    },
+    {
         path: "/super-admin/faculties/:id",
         element: (
             <RoleGuard allowedRoles={[UserRole.ADMIN]}>
                 <FacultyDetailPage />
+            </RoleGuard>
+        ),
+    },
+    {
+        path: "/super-admin/faculties/:id/edit",
+        element: (
+            <RoleGuard allowedRoles={[UserRole.ADMIN]}>
+                <EditFacultyPage />
             </RoleGuard>
         ),
     },

--- a/src/features/super-admin/students/components/StudentAcademicFields.tsx
+++ b/src/features/super-admin/students/components/StudentAcademicFields.tsx
@@ -1,0 +1,137 @@
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { AdmissionType } from "../../../../utils/enum";
+import { useGetBatchesQuery, useGetCoursesQuery, useGetDepartmentsQuery } from "../../../../state/services/endpoints/academics";
+
+interface StudentAcademicFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const admissionTypeOptions = Object.values(AdmissionType).map((value) => ({ value, label: value }));
+
+const StudentAcademicFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: StudentAcademicFieldsProps) => {
+    const { data: batchesData, isFetching: isBatchesLoading } = useGetBatchesQuery({ limit: 100 });
+    const { data: coursesData, isFetching: isCoursesLoading } = useGetCoursesQuery(
+        { batchId: values.batchId, limit: 100 },
+        { skip: !values.batchId }
+    );
+
+    const selectedCourse = coursesData?.data?.find((c) => c._id === values.courseId);
+
+    const { data: departmentsData, isFetching: isDepartmentsLoading } = useGetDepartmentsQuery(
+        { batchCourseId: selectedCourse?.batchCourseId as string, limit: 100 },
+        { skip: !selectedCourse?.batchCourseId }
+    );
+
+    const selectedDepartment = departmentsData?.data?.find((d) => d._id === values.departmentId);
+    const sections = selectedDepartment?.sections || [];
+
+    const batchOptions = (batchesData?.data || []).map((b) => ({ value: b._id, label: b.batchName }));
+    const courseOptions = (coursesData?.data || []).map((c) => ({ value: c._id, label: c.courseName }));
+    const departmentOptions = (departmentsData?.data || []).map((d) => ({ value: d._id, label: d.deptName }));
+    const sectionOptions = sections.map((s) => ({ value: s._id, label: s.sectionName }));
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Select
+                    id="batchId"
+                    name="batchId"
+                    label="Batch"
+                    options={batchOptions}
+                    value={values.batchId}
+                    loading={isBatchesLoading}
+                    onChange={(value) => {
+                        setFieldValue("batchId", value);
+                        setFieldValue("courseId", "");
+                        setFieldValue("departmentId", "");
+                        setFieldValue("sectionId", "");
+                    }}
+                    error={errors.batchId}
+                    touched={touched.batchId}
+                    required
+                />
+                <Select
+                    id="courseId"
+                    name="courseId"
+                    label="Course"
+                    options={courseOptions}
+                    value={values.courseId}
+                    loading={isCoursesLoading}
+                    disabled={!values.batchId}
+                    onChange={(value) => {
+                        setFieldValue("courseId", value);
+                        setFieldValue("departmentId", "");
+                        setFieldValue("sectionId", "");
+                    }}
+                    error={errors.courseId}
+                    touched={touched.courseId}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Select
+                    id="departmentId"
+                    name="departmentId"
+                    label="Department"
+                    options={departmentOptions}
+                    value={values.departmentId}
+                    loading={isDepartmentsLoading}
+                    disabled={!values.courseId}
+                    onChange={(value) => {
+                        setFieldValue("departmentId", value);
+                        setFieldValue("sectionId", "");
+                    }}
+                    error={errors.departmentId}
+                    touched={touched.departmentId}
+                    required
+                />
+                <Select
+                    id="sectionId"
+                    name="sectionId"
+                    label="Section"
+                    options={sectionOptions}
+                    value={values.sectionId}
+                    disabled={!values.departmentId}
+                    onChange={(value) => setFieldValue("sectionId", value)}
+                    error={errors.sectionId}
+                    touched={touched.sectionId}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="currentSemester"
+                    name="currentSemester"
+                    type="number"
+                    label="Current Semester"
+                    placeholder="1"
+                    value={values.currentSemester}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.currentSemester}
+                    touched={touched.currentSemester}
+                    required
+                />
+                <Select
+                    id="admissionType"
+                    name="admissionType"
+                    label="Admission Type"
+                    options={admissionTypeOptions}
+                    value={values.admissionType}
+                    onChange={(value) => setFieldValue("admissionType", value)}
+                    error={errors.admissionType}
+                    touched={touched.admissionType}
+                    required
+                />
+            </div>
+        </div>
+    );
+};
+
+export default StudentAcademicFields;

--- a/src/features/super-admin/students/components/StudentContactFields.tsx
+++ b/src/features/super-admin/students/components/StudentContactFields.tsx
@@ -1,0 +1,76 @@
+import InputField from "../../../../common/ui/Input";
+import EmergencyContactFields from "../../../../common/form-sections/EmergencyContactFields";
+
+interface StudentContactFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+    studentEmail?: string;
+}
+
+const StudentContactFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue, studentEmail }: StudentContactFieldsProps) => {
+    return (
+        <div className="space-y-4">
+            {studentEmail && (
+                <InputField
+                    id="studentEmail"
+                    name="studentEmail"
+                    label="Student Email (auto-generated, read-only)"
+                    value={studentEmail}
+                    disabled
+                />
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="personalEmail"
+                    name="personalEmail"
+                    type="email"
+                    label="Personal Email"
+                    placeholder="Personal email address"
+                    value={values.personalEmail}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.personalEmail}
+                    touched={touched.personalEmail}
+                    required
+                />
+                <InputField
+                    id="phoneNumber"
+                    name="phoneNumber"
+                    label="Phone Number"
+                    placeholder="+91XXXXXXXXXX"
+                    value={values.phoneNumber}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.phoneNumber}
+                    touched={touched.phoneNumber}
+                    required
+                />
+            </div>
+            <InputField
+                id="alternatePhoneNumber"
+                name="alternatePhoneNumber"
+                label="Alternate Phone Number"
+                placeholder="+91XXXXXXXXXX (optional)"
+                value={values.alternatePhoneNumber}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.alternatePhoneNumber}
+                touched={touched.alternatePhoneNumber}
+            />
+            <EmergencyContactFields
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+                setFieldValue={setFieldValue}
+            />
+        </div>
+    );
+};
+
+export default StudentContactFields;

--- a/src/features/super-admin/students/components/StudentEducationHistoryFields.tsx
+++ b/src/features/super-admin/students/components/StudentEducationHistoryFields.tsx
@@ -1,0 +1,140 @@
+import { FieldArray } from "formik";
+import { Plus, Trash2 } from "lucide-react";
+import Button from "../../../../common/ui/Button";
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { EducationLevel, Qualification, BoardType } from "../../../../utils/enum";
+
+interface StudentEducationHistoryFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const emptyEducationRecord = {
+    level: "",
+    qualification: "",
+    boardOrUniversity: "",
+    institutionName: "",
+    yearOfPassing: "",
+    percentageOrCGPA: "",
+};
+
+const levelOptions = Object.values(EducationLevel).map((value) => ({ value, label: value }));
+const qualificationOptions = Object.values(Qualification).map((value) => ({ value, label: value }));
+const boardOptions = Object.values(BoardType).map((value) => ({ value, label: value }));
+
+const StudentEducationHistoryFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: StudentEducationHistoryFieldsProps) => {
+    const educationHistory = values.educationHistory || [];
+
+    return (
+        <FieldArray name="educationHistory">
+            {({ push, remove }) => (
+                <div className="space-y-6">
+                    {educationHistory.map((_: any, index: number) => {
+                        const itemErrors = (errors.educationHistory?.[index] as any) || {};
+                        const itemTouched = (touched.educationHistory?.[index] as any) || {};
+
+                        return (
+                            <div key={index} className="p-4 border border-borderLight rounded-lg space-y-4">
+                                <div className="flex items-center justify-between">
+                                    <h5 className="text-sm font-semibold text-textSecondary">Education Record {index + 1}</h5>
+                                    {educationHistory.length > 1 && (
+                                        <button
+                                            type="button"
+                                            onClick={() => remove(index)}
+                                            className="text-red-600 hover:text-red-700 cursor-pointer"
+                                        >
+                                            <Trash2 className="h-4 w-4" />
+                                        </button>
+                                    )}
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <Select
+                                        id={`educationHistory.${index}.level`}
+                                        name={`educationHistory.${index}.level`}
+                                        label="Level"
+                                        options={levelOptions}
+                                        value={educationHistory[index].level}
+                                        onChange={(value) => setFieldValue(`educationHistory.${index}.level`, value)}
+                                        error={itemErrors.level}
+                                        touched={itemTouched.level}
+                                        required
+                                    />
+                                    <Select
+                                        id={`educationHistory.${index}.qualification`}
+                                        name={`educationHistory.${index}.qualification`}
+                                        label="Qualification"
+                                        options={qualificationOptions}
+                                        value={educationHistory[index].qualification}
+                                        onChange={(value) => setFieldValue(`educationHistory.${index}.qualification`, value)}
+                                        error={itemErrors.qualification}
+                                        touched={itemTouched.qualification}
+                                        required
+                                    />
+                                    <Select
+                                        id={`educationHistory.${index}.boardOrUniversity`}
+                                        name={`educationHistory.${index}.boardOrUniversity`}
+                                        label="Board / University"
+                                        options={boardOptions}
+                                        value={educationHistory[index].boardOrUniversity}
+                                        onChange={(value) => setFieldValue(`educationHistory.${index}.boardOrUniversity`, value)}
+                                        error={itemErrors.boardOrUniversity}
+                                        touched={itemTouched.boardOrUniversity}
+                                        required
+                                    />
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <InputField
+                                        id={`educationHistory.${index}.institutionName`}
+                                        name={`educationHistory.${index}.institutionName`}
+                                        label="Institution Name"
+                                        value={educationHistory[index].institutionName}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.institutionName}
+                                        touched={itemTouched.institutionName}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.yearOfPassing`}
+                                        name={`educationHistory.${index}.yearOfPassing`}
+                                        type="number"
+                                        label="Year of Passing"
+                                        value={educationHistory[index].yearOfPassing}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.yearOfPassing}
+                                        touched={itemTouched.yearOfPassing}
+                                        required
+                                    />
+                                    <InputField
+                                        id={`educationHistory.${index}.percentageOrCGPA`}
+                                        name={`educationHistory.${index}.percentageOrCGPA`}
+                                        type="number"
+                                        label="Percentage / CGPA"
+                                        value={educationHistory[index].percentageOrCGPA}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        error={itemErrors.percentageOrCGPA}
+                                        touched={itemTouched.percentageOrCGPA}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                        );
+                    })}
+
+                    <Button type="button" variant="outline" size="sm" icon={Plus} onClick={() => push({ ...emptyEducationRecord })}>
+                        Add Education Record
+                    </Button>
+                </div>
+            )}
+        </FieldArray>
+    );
+};
+
+export default StudentEducationHistoryFields;

--- a/src/features/super-admin/students/components/StudentParentGuardianFields.tsx
+++ b/src/features/super-admin/students/components/StudentParentGuardianFields.tsx
@@ -1,0 +1,90 @@
+import InputField from "../../../../common/ui/Input";
+
+interface StudentParentGuardianFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+}
+
+const StudentParentGuardianFields = ({ values, errors, touched, handleChange, handleBlur }: StudentParentGuardianFieldsProps) => {
+    const renderGroup = (prefix: "father" | "mother" | "guardian", title: string, showRelation: boolean) => {
+        const group = values?.[prefix] || {};
+        const groupErrors = errors?.[prefix] || {};
+        const groupTouched = touched?.[prefix] || {};
+
+        return (
+            <div className="space-y-4">
+                <h4 className="text-sm font-semibold text-textSecondary">{title} (optional)</h4>
+                <div className={`grid grid-cols-1 gap-4 ${showRelation ? "md:grid-cols-4" : "md:grid-cols-3"}`}>
+                    <InputField
+                        id={`${prefix}.name`}
+                        name={`${prefix}.name`}
+                        label="Name"
+                        value={group.name}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={groupErrors.name}
+                        touched={groupTouched.name}
+                    />
+                    {showRelation && (
+                        <InputField
+                            id={`${prefix}.relation`}
+                            name={`${prefix}.relation`}
+                            label="Relation"
+                            placeholder="e.g. Uncle"
+                            value={group.relation}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            error={groupErrors.relation}
+                            touched={groupTouched.relation}
+                        />
+                    )}
+                    <InputField
+                        id={`${prefix}.phoneNumber`}
+                        name={`${prefix}.phoneNumber`}
+                        label="Phone Number"
+                        placeholder="+91XXXXXXXXXX"
+                        value={group.phoneNumber}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={groupErrors.phoneNumber}
+                        touched={groupTouched.phoneNumber}
+                    />
+                    <InputField
+                        id={`${prefix}.email`}
+                        name={`${prefix}.email`}
+                        type="email"
+                        label="Email"
+                        value={group.email}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={groupErrors.email}
+                        touched={groupTouched.email}
+                    />
+                </div>
+                <InputField
+                    id={`${prefix}.occupation`}
+                    name={`${prefix}.occupation`}
+                    label="Occupation"
+                    value={group.occupation}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={groupErrors.occupation}
+                    touched={groupTouched.occupation}
+                />
+            </div>
+        );
+    };
+
+    return (
+        <div className="space-y-6">
+            {renderGroup("father", "Father's Details", false)}
+            {renderGroup("mother", "Mother's Details", false)}
+            {renderGroup("guardian", "Guardian's Details", true)}
+        </div>
+    );
+};
+
+export default StudentParentGuardianFields;

--- a/src/features/super-admin/students/components/StudentPersonalFields.tsx
+++ b/src/features/super-admin/students/components/StudentPersonalFields.tsx
@@ -1,0 +1,98 @@
+import InputField from "../../../../common/ui/Input";
+import Select from "../../../../common/ui/Select";
+import { Gender } from "../../../../utils/enum";
+
+interface StudentPersonalFieldsProps {
+    values: any;
+    errors: any;
+    touched: any;
+    handleChange: (e: React.ChangeEvent<any>) => void;
+    handleBlur: (e: React.FocusEvent<any>) => void;
+    setFieldValue: (field: string, value: any) => void;
+}
+
+const genderOptions = Object.values(Gender).map((value) => ({ value, label: value }));
+
+const StudentPersonalFields = ({ values, errors, touched, handleChange, handleBlur, setFieldValue }: StudentPersonalFieldsProps) => {
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    id="firstName"
+                    name="firstName"
+                    label="First Name"
+                    placeholder="First name"
+                    value={values.firstName}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.firstName}
+                    touched={touched.firstName}
+                    required
+                />
+                <InputField
+                    id="lastName"
+                    name="lastName"
+                    label="Last Name"
+                    placeholder="Last name"
+                    value={values.lastName}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.lastName}
+                    touched={touched.lastName}
+                    required
+                />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Select
+                    id="gender"
+                    name="gender"
+                    label="Gender"
+                    options={genderOptions}
+                    value={values.gender}
+                    onChange={(value) => setFieldValue("gender", value)}
+                    error={errors.gender}
+                    touched={touched.gender}
+                    required
+                />
+                <InputField
+                    id="dateOfBirth"
+                    name="dateOfBirth"
+                    type="text"
+                    label="Date of Birth"
+                    placeholder="YYYY-MM-DD"
+                    value={values.dateOfBirth}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.dateOfBirth}
+                    touched={touched.dateOfBirth}
+                    required
+                />
+                <InputField
+                    id="religion"
+                    name="religion"
+                    label="Religion"
+                    placeholder="Religion (optional)"
+                    value={values.religion}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    error={errors.religion}
+                    touched={touched.religion}
+                />
+            </div>
+            <InputField
+                id="profilePhotoUrl"
+                name="profilePhotoUrl"
+                label="Profile Photo URL"
+                placeholder="https://..."
+                value={values.profilePhotoUrl}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.profilePhotoUrl}
+                touched={touched.profilePhotoUrl}
+                required
+            />
+        </div>
+    );
+};
+
+export default StudentPersonalFields;

--- a/src/features/super-admin/students/formik/create-student.schema.ts
+++ b/src/features/super-admin/students/formik/create-student.schema.ts
@@ -1,0 +1,58 @@
+import * as Yup from 'yup';
+import { Gender, AdmissionType, EducationLevel, Qualification, BoardType } from '../../../../utils/enum';
+import { addressSchema, emergencyContactSchema, phoneValidator } from '../../../../common/form-sections/shared.schema';
+
+const educationHistorySchema = Yup.object({
+    level: Yup.string().oneOf(Object.values(EducationLevel)).required('Level is required'),
+    qualification: Yup.string().oneOf(Object.values(Qualification)).required('Qualification is required'),
+    boardOrUniversity: Yup.string().oneOf(Object.values(BoardType)).required('Board/University is required'),
+    institutionName: Yup.string().required('Institution name is required').max(100),
+    yearOfPassing: Yup.number().typeError('Must be a number').required('Year of passing is required'),
+    percentageOrCGPA: Yup.number().typeError('Must be a number').required('Percentage/CGPA is required'),
+});
+
+const parentInfoSchema = Yup.object({
+    name: Yup.string().max(50),
+    phoneNumber: phoneValidator,
+    email: Yup.string().email('Must be a valid email'),
+    occupation: Yup.string().max(50),
+});
+
+const guardianInfoSchema = parentInfoSchema.shape({
+    relation: Yup.string(),
+});
+
+export const createStudentValidationSchema = Yup.object({
+    firstName: Yup.string().required('First name is required').max(30),
+    lastName: Yup.string().required('Last name is required').max(30),
+    gender: Yup.string().oneOf(Object.values(Gender)).required('Gender is required'),
+    dateOfBirth: Yup.string().required('Date of birth is required'),
+    profilePhotoUrl: Yup.string().required('Profile photo URL is required'),
+    religion: Yup.string().max(30),
+
+    personalEmail: Yup.string().email('Must be a valid email').required('Personal email is required'),
+    phoneNumber: phoneValidator.required('Phone number is required'),
+    alternatePhoneNumber: phoneValidator,
+    emergencyContact: emergencyContactSchema,
+
+    currentAddress: addressSchema,
+    sameAsCurrent: Yup.boolean(),
+    permanentAddress: Yup.object().when('sameAsCurrent', {
+        is: false,
+        then: () => addressSchema,
+        otherwise: (schema) => schema.notRequired(),
+    }),
+
+    batchId: Yup.string().required('Batch is required'),
+    courseId: Yup.string().required('Course is required'),
+    departmentId: Yup.string().required('Department is required'),
+    sectionId: Yup.string().required('Section is required'),
+    currentSemester: Yup.number().typeError('Must be a number').required('Current semester is required').min(1),
+    admissionType: Yup.string().oneOf(Object.values(AdmissionType)).required('Admission type is required'),
+
+    father: parentInfoSchema.notRequired(),
+    mother: parentInfoSchema.notRequired(),
+    guardian: guardianInfoSchema.notRequired(),
+
+    educationHistory: Yup.array().of(educationHistorySchema).min(1, 'At least one education record is required'),
+});

--- a/src/features/super-admin/students/formik/edit-student.schema.ts
+++ b/src/features/super-admin/students/formik/edit-student.schema.ts
@@ -1,0 +1,51 @@
+import * as Yup from 'yup';
+import { Gender, EducationLevel, Qualification, BoardType } from '../../../../utils/enum';
+import { addressSchema, emergencyContactSchema, phoneValidator } from '../../../../common/form-sections/shared.schema';
+
+const educationHistorySchema = Yup.object({
+    level: Yup.string().oneOf(Object.values(EducationLevel)).required('Level is required'),
+    qualification: Yup.string().oneOf(Object.values(Qualification)).required('Qualification is required'),
+    boardOrUniversity: Yup.string().oneOf(Object.values(BoardType)).required('Board/University is required'),
+    institutionName: Yup.string().required('Institution name is required').max(100),
+    yearOfPassing: Yup.number().typeError('Must be a number').required('Year of passing is required'),
+    percentageOrCGPA: Yup.number().typeError('Must be a number').required('Percentage/CGPA is required'),
+});
+
+const parentInfoSchema = Yup.object({
+    name: Yup.string().max(50),
+    phoneNumber: phoneValidator,
+    email: Yup.string().email('Must be a valid email'),
+    occupation: Yup.string().max(50),
+});
+
+const guardianInfoSchema = parentInfoSchema.shape({
+    relation: Yup.string(),
+});
+
+export const editStudentValidationSchema = Yup.object({
+    firstName: Yup.string().required('First name is required').max(30),
+    lastName: Yup.string().required('Last name is required').max(30),
+    gender: Yup.string().oneOf(Object.values(Gender)).required('Gender is required'),
+    dateOfBirth: Yup.string().required('Date of birth is required'),
+    profilePhotoUrl: Yup.string().required('Profile photo URL is required'),
+    religion: Yup.string().max(30),
+
+    personalEmail: Yup.string().email('Must be a valid email').required('Personal email is required'),
+    phoneNumber: phoneValidator.required('Phone number is required'),
+    alternatePhoneNumber: phoneValidator,
+    emergencyContact: emergencyContactSchema,
+
+    currentAddress: addressSchema,
+    sameAsCurrent: Yup.boolean(),
+    permanentAddress: Yup.object().when('sameAsCurrent', {
+        is: false,
+        then: () => addressSchema,
+        otherwise: (schema) => schema.notRequired(),
+    }),
+
+    father: parentInfoSchema.notRequired(),
+    mother: parentInfoSchema.notRequired(),
+    guardian: guardianInfoSchema.notRequired(),
+
+    educationHistory: Yup.array().of(educationHistorySchema).min(1, 'At least one education record is required'),
+});

--- a/src/features/super-admin/students/pages/CreateStudentPage.tsx
+++ b/src/features/super-admin/students/pages/CreateStudentPage.tsx
@@ -1,0 +1,129 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { useNavigate } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import { Container } from "../../../../common/ui/Container";
+import { PageHeader } from "../../../../common/ui/PageHeader";
+import { Country } from "../../../../utils/enum";
+import AddressSection from "../../../../common/form-sections/AddressSection";
+import { createStudentValidationSchema } from "../formik/create-student.schema";
+import { useCreateStudentMutation } from "../../../../state/services/endpoints/students";
+import StudentPersonalFields from "../components/StudentPersonalFields";
+import StudentContactFields from "../components/StudentContactFields";
+import StudentAcademicFields from "../components/StudentAcademicFields";
+import StudentParentGuardianFields from "../components/StudentParentGuardianFields";
+import StudentEducationHistoryFields from "../components/StudentEducationHistoryFields";
+
+const emptyParent = { name: '', phoneNumber: '', email: '', occupation: '' };
+const emptyGuardian = { ...emptyParent, relation: '' };
+
+const initialValues = {
+    firstName: '', lastName: '', gender: '', dateOfBirth: '', profilePhotoUrl: '', religion: '',
+    personalEmail: '', phoneNumber: '', alternatePhoneNumber: '',
+    emergencyContact: { name: '', relation: '', phoneNumber: '' },
+    currentAddress: { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+    sameAsCurrent: true,
+    permanentAddress: { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+    batchId: '', courseId: '', departmentId: '', sectionId: '', currentSemester: '', admissionType: '',
+    father: { ...emptyParent },
+    mother: { ...emptyParent },
+    guardian: { ...emptyGuardian },
+    educationHistory: [{ level: '', qualification: '', boardOrUniversity: '', institutionName: '', yearOfPassing: '', percentageOrCGPA: '' }],
+};
+
+function isBlankGroup(group: Record<string, any>) {
+    return Object.values(group).every((value) => !value);
+}
+
+const CreateStudentPage = () => {
+    const navigate = useNavigate();
+    const [createStudent, { isLoading }] = useCreateStudentMutation();
+
+    const handleSubmit = async (values: typeof initialValues, { setSubmitting }: any) => {
+        try {
+            const payload = {
+                ...values,
+                alternatePhoneNumber: values.alternatePhoneNumber || undefined,
+                currentSemester: Number(values.currentSemester),
+                currentAddress: { ...values.currentAddress, country: Country.INDIA },
+                permanentAddress: values.sameAsCurrent ? undefined : { ...values.permanentAddress, country: Country.INDIA },
+                father: isBlankGroup(values.father) ? undefined : values.father,
+                mother: isBlankGroup(values.mother) ? undefined : values.mother,
+                guardian: isBlankGroup(values.guardian) ? undefined : values.guardian,
+                educationHistory: values.educationHistory.map((edu) => ({
+                    ...edu,
+                    yearOfPassing: Number(edu.yearOfPassing),
+                    percentageOrCGPA: Number(edu.percentageOrCGPA),
+                })),
+            };
+
+            const response = await createStudent(payload as any).unwrap();
+            toast.success(response.message || 'Student created successfully');
+            navigate('/super-admin/students');
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to create student');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <PageHeader>Add Student</PageHeader>
+            <Container>
+                <div className="py-6">
+                    <Formik
+                        initialValues={initialValues}
+                        validationSchema={createStudentValidationSchema}
+                        onSubmit={handleSubmit}
+                    >
+                        {({ values, errors, touched, handleChange, handleBlur, setFieldValue, isSubmitting }) => (
+                            <Form className="space-y-10">
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Personal Details</h3>
+                                    <StudentPersonalFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Contact Information</h3>
+                                    <StudentContactFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Address</h3>
+                                    <AddressSection values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Academic Placement</h3>
+                                    <StudentAcademicFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Parent / Guardian Details</h3>
+                                    <StudentParentGuardianFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Education History</h3>
+                                    <StudentEducationHistoryFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <div className="flex justify-end gap-3 pt-4 border-t border-borderLight">
+                                    <Button type="button" variant="outline" onClick={() => navigate('/super-admin/students')}>
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" variant="primary" loading={isSubmitting || isLoading} disabled={isSubmitting || isLoading}>
+                                        {isSubmitting || isLoading ? '' : 'Create Student'}
+                                    </Button>
+                                </div>
+                            </Form>
+                        )}
+                    </Formik>
+                </div>
+            </Container>
+        </>
+    );
+};
+
+export default CreateStudentPage;

--- a/src/features/super-admin/students/pages/EditStudentPage.tsx
+++ b/src/features/super-admin/students/pages/EditStudentPage.tsx
@@ -1,0 +1,176 @@
+import toast from "react-hot-toast";
+import { Formik, Form } from 'formik';
+import { useNavigate, useParams } from 'react-router-dom';
+import Button from "../../../../common/ui/Button";
+import { Container } from "../../../../common/ui/Container";
+import { PageHeader } from "../../../../common/ui/PageHeader";
+import { Country } from "../../../../utils/enum";
+import AddressSection from "../../../../common/form-sections/AddressSection";
+import { editStudentValidationSchema } from "../formik/edit-student.schema";
+import { useGetStudentByIdQuery, useUpdateStudentMutation } from "../../../../state/services/endpoints/students";
+import StudentPersonalFields from "../components/StudentPersonalFields";
+import StudentContactFields from "../components/StudentContactFields";
+import StudentParentGuardianFields from "../components/StudentParentGuardianFields";
+import StudentEducationHistoryFields from "../components/StudentEducationHistoryFields";
+
+const emptyParent = { name: '', phoneNumber: '', email: '', occupation: '' };
+const emptyGuardian = { ...emptyParent, relation: '' };
+
+function isBlankGroup(group: Record<string, any>) {
+    return Object.values(group).every((value) => !value);
+}
+
+const EditStudentPage = () => {
+    const navigate = useNavigate();
+    const { id } = useParams<{ id: string }>();
+    const { data, isLoading: isLoadingStudent } = useGetStudentByIdQuery(id as string, { skip: !id });
+    const [updateStudent, { isLoading: isUpdating }] = useUpdateStudentMutation();
+
+    if (isLoadingStudent || !data?.data) {
+        return (
+            <>
+                <PageHeader>Edit Student</PageHeader>
+                <Container>
+                    <div className="py-6 text-textSecondary">Loading student details...</div>
+                </Container>
+            </>
+        );
+    }
+
+    const student = data.data;
+
+    const initialValues = {
+        firstName: student.personalDetails.firstName,
+        lastName: student.personalDetails.lastName,
+        gender: student.personalDetails.gender,
+        dateOfBirth: student.personalDetails.dateOfBirth,
+        profilePhotoUrl: student.personalDetails.profilePhotoUrl,
+        religion: student.personalDetails.religion || '',
+
+        personalEmail: student.contactDetails.personalEmail,
+        phoneNumber: student.contactDetails.phoneNumber,
+        alternatePhoneNumber: student.contactDetails.alternatePhoneNumber || '',
+        emergencyContact: { ...student.contactDetails.emergencyContact },
+
+        currentAddress: { ...student.addressDetails.currentAddress },
+        sameAsCurrent: student.addressDetails.sameAsCurrent,
+        permanentAddress: student.addressDetails.permanentAddress
+            ? { ...student.addressDetails.permanentAddress }
+            : { addressLine1: '', addressLine2: '', city: '', state: '', pincode: '' },
+
+        father: student.parentDetails?.father ? { ...emptyParent, ...student.parentDetails.father } : { ...emptyParent },
+        mother: student.parentDetails?.mother ? { ...emptyParent, ...student.parentDetails.mother } : { ...emptyParent },
+        guardian: student.parentDetails?.guardian ? { ...emptyGuardian, ...student.parentDetails.guardian } : { ...emptyGuardian },
+
+        educationHistory: student.educationHistory.length > 0
+            ? student.educationHistory.map((edu) => ({
+                level: edu.level,
+                qualification: edu.qualification,
+                boardOrUniversity: edu.boardOrUniversity,
+                institutionName: edu.institutionName,
+                yearOfPassing: edu.yearOfPassing,
+                percentageOrCGPA: edu.percentageOrCGPA,
+            }))
+            : [{ level: '', qualification: '', boardOrUniversity: '', institutionName: '', yearOfPassing: '', percentageOrCGPA: '' }],
+    };
+
+    const handleSubmit = async (values: typeof initialValues, { setSubmitting }: any) => {
+        try {
+            const payload = {
+                ...values,
+                alternatePhoneNumber: values.alternatePhoneNumber || undefined,
+                currentAddress: { ...values.currentAddress, country: Country.INDIA },
+                permanentAddress: values.sameAsCurrent ? undefined : { ...values.permanentAddress, country: Country.INDIA },
+                father: isBlankGroup(values.father) ? undefined : values.father,
+                mother: isBlankGroup(values.mother) ? undefined : values.mother,
+                guardian: isBlankGroup(values.guardian) ? undefined : values.guardian,
+                educationHistory: values.educationHistory.map((edu) => ({
+                    ...edu,
+                    yearOfPassing: Number(edu.yearOfPassing),
+                    percentageOrCGPA: Number(edu.percentageOrCGPA),
+                })),
+            };
+
+            const response = await updateStudent({ id: id as string, data: payload as any }).unwrap();
+            toast.success(response.message || 'Student updated successfully');
+            navigate(`/super-admin/students/${id}`);
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to update student');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <PageHeader>Edit Student</PageHeader>
+            <Container>
+                <div className="py-6 space-y-10">
+                    <section className="space-y-2">
+                        <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Academic Placement (read-only)</h3>
+                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                            <div><span className="text-textTertiary">Roll Number:</span> <span className="text-textPrimary">{student.academicDetails.rollNumber}</span></div>
+                            <div><span className="text-textTertiary">Batch:</span> <span className="text-textPrimary">{student.academicDetails.batchName}</span></div>
+                            <div><span className="text-textTertiary">Course:</span> <span className="text-textPrimary">{student.academicDetails.courseName}</span></div>
+                            <div><span className="text-textTertiary">Department:</span> <span className="text-textPrimary">{student.academicDetails.departmentName}</span></div>
+                            <div><span className="text-textTertiary">Section:</span> <span className="text-textPrimary">{student.academicDetails.sectionName}</span></div>
+                            <div><span className="text-textTertiary">Semester:</span> <span className="text-textPrimary">{student.academicDetails.currentSemester}</span></div>
+                            <div><span className="text-textTertiary">Admission Type:</span> <span className="text-textPrimary">{student.academicDetails.admissionType}</span></div>
+                            <div><span className="text-textTertiary">Status:</span> <span className="text-textPrimary">{student.academicDetails.status}</span></div>
+                        </div>
+                    </section>
+
+                    <Formik
+                        initialValues={initialValues}
+                        validationSchema={editStudentValidationSchema}
+                        onSubmit={handleSubmit}
+                        enableReinitialize
+                    >
+                        {({ values, errors, touched, handleChange, handleBlur, setFieldValue, isSubmitting }) => (
+                            <Form className="space-y-10">
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Personal Details</h3>
+                                    <StudentPersonalFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Contact Information</h3>
+                                    <StudentContactFields
+                                        values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue}
+                                        studentEmail={student.contactDetails.studentEmail}
+                                    />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Address</h3>
+                                    <AddressSection values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Parent / Guardian Details</h3>
+                                    <StudentParentGuardianFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} />
+                                </section>
+
+                                <section className="space-y-4">
+                                    <h3 className="text-lg font-semibold text-textPrimary border-b border-borderLight pb-2">Education History</h3>
+                                    <StudentEducationHistoryFields values={values} errors={errors} touched={touched} handleChange={handleChange} handleBlur={handleBlur} setFieldValue={setFieldValue} />
+                                </section>
+
+                                <div className="flex justify-end gap-3 pt-4 border-t border-borderLight">
+                                    <Button type="button" variant="outline" onClick={() => navigate(`/super-admin/students/${id}`)}>
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" variant="primary" loading={isSubmitting || isUpdating} disabled={isSubmitting || isUpdating}>
+                                        {isSubmitting || isUpdating ? '' : 'Save Changes'}
+                                    </Button>
+                                </div>
+                            </Form>
+                        )}
+                    </Formik>
+                </div>
+            </Container>
+        </>
+    );
+};
+
+export default EditStudentPage;

--- a/src/features/super-admin/students/pages/StudentDetailPage.tsx
+++ b/src/features/super-admin/students/pages/StudentDetailPage.tsx
@@ -1,16 +1,33 @@
+import toast from "react-hot-toast";
+import { useState } from "react";
+import Modal from "../../../../common/ui/Modal";
 import Button from "../../../../common/ui/Button";
 import Timeline from "../../../../common/ui/Timeline";
 import { useParams, useNavigate } from "react-router-dom";
 import { Container } from "../../../../common/ui/Container";
 import { PageHeader } from "../../../../common/ui/PageHeader";
 import StudentDetailSkeleton from "../components/StudentDetailSkeleton";
-import { useGetStudentByIdQuery } from "../../../../state/services/endpoints/students";
+import { useGetStudentByIdQuery, useDeleteStudentMutation } from "../../../../state/services/endpoints/students";
 import { BookOpen, Calendar, Flag, GraduationCap, MapPin, Phone, User, Users } from "lucide-react";
 
 const StudentDetailPage = () => {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const { data, isLoading, error } = useGetStudentByIdQuery(id!);
+    const [deleteStudent, { isLoading: isDeleting }] = useDeleteStudentMutation();
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+    const handleDelete = async () => {
+        try {
+            const response = await deleteStudent(id!).unwrap();
+            toast.success(response.message || 'Student deactivated successfully');
+            navigate("/super-admin/students");
+        } catch (error: any) {
+            toast.error(error.data?.message || 'Failed to delete student');
+        } finally {
+            setIsDeleteModalOpen(false);
+        }
+    };
 
     if (isLoading) {
         return (
@@ -52,7 +69,7 @@ const StudentDetailPage = () => {
         <>
             <PageHeader>Student Details</PageHeader>
             <Container>
-                <div className="mb-6">
+                <div className="mb-6 flex items-center justify-between">
                     <Button
                         variant="primary"
                         size="sm"
@@ -60,6 +77,22 @@ const StudentDetailPage = () => {
                     >
                         ← Back to Students
                     </Button>
+                    <div className="flex items-center gap-3">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => navigate(`/super-admin/students/${id}/edit`)}
+                        >
+                            Edit
+                        </Button>
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => setIsDeleteModalOpen(true)}
+                        >
+                            Delete
+                        </Button>
+                    </div>
                 </div>
 
                 <div className="space-y-6 mb-6">
@@ -453,6 +486,27 @@ const StudentDetailPage = () => {
                 </div>
 
             </Container>
+
+            <Modal
+                isOpen={isDeleteModalOpen}
+                onClose={() => setIsDeleteModalOpen(false)}
+                title="Delete Student"
+                size="sm"
+            >
+                <div className="space-y-6">
+                    <p className="text-sm text-textSecondary">
+                        Are you sure you want to delete <span className="font-semibold text-textPrimary">{fullName}</span>? This will deactivate their account and they will no longer be able to log in.
+                    </p>
+                    <div className="flex justify-end gap-3">
+                        <Button variant="outline" size="sm" onClick={() => setIsDeleteModalOpen(false)}>
+                            Cancel
+                        </Button>
+                        <Button variant="danger" size="sm" loading={isDeleting} disabled={isDeleting} onClick={handleDelete}>
+                            {isDeleting ? '' : 'Delete'}
+                        </Button>
+                    </div>
+                </div>
+            </Modal>
         </>
     );
 };

--- a/src/features/super-admin/students/pages/StudentsPage.tsx
+++ b/src/features/super-admin/students/pages/StudentsPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import Modal from "../../../../common/ui/Modal";
 import Button from "../../../../common/ui/Button";
 import { Container } from "../../../../common/ui/Container";
 import { PageHeader } from "../../../../common/ui/PageHeader";
@@ -13,7 +12,6 @@ const StudentsPage = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
     const [searchTerm, setSearchTerm] = useState("");
-    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const { data, isLoading, isFetching } = useGetAllStudentsQuery({
         page,
@@ -38,14 +36,6 @@ const StudentsPage = () => {
     const handleRowClick = useCallback((row: StudentsData) => {
         navigate(`/super-admin/students/${row.id}`);
     }, [navigate]);
-
-    const handleOpenModal = useCallback(() => {
-        setIsModalOpen(true);
-    }, []);
-
-    const handleCloseModal = useCallback(() => {
-        setIsModalOpen(false);
-    }, []);
 
     const columns: ColumnDef<StudentsData, any>[] = [
         {
@@ -130,15 +120,17 @@ const StudentsPage = () => {
     return (
         <>
             <PageHeader>Students</PageHeader>
-            <div className="flex justify-end">
-                <Button
-                    type="submit"
-                    variant="primary"
-                    size="md"
-                    onClick={handleOpenModal}
-                >
-                    Add Student
-                </Button>
+            <div className="px-6">
+                <div className="flex justify-end">
+                    <Button
+                        type="button"
+                        variant="primary"
+                        size="md"
+                        onClick={() => navigate('/super-admin/students/create')}
+                    >
+                        Add Student
+                    </Button>
+                </div>
             </div>
 
             <Container>
@@ -159,15 +151,6 @@ const StudentsPage = () => {
                     />
                 </div>
             </Container>
-
-            <Modal
-                isOpen={isModalOpen}
-                onClose={handleCloseModal}
-                title="Add New Student"
-                size="md"
-            >
-                <div></div>
-            </Modal>
         </>
     );
 };

--- a/src/layouts/root/RootLayout.tsx
+++ b/src/layouts/root/RootLayout.tsx
@@ -122,7 +122,7 @@ export function RootLayout() {
                 </aside>
 
                 {/* Main Content Area */}
-                <div className="flex-1 flex flex-col">
+                <div className="flex-1 flex flex-col min-w-0">
                     <header className="h-16 bg-whiteColor border-b border-borderLight flex items-center justify-end px-6 flex-shrink-0 shadow-sm">
                         <div className="flex items-center gap-4">
                             <div className="flex flex-col text-right">

--- a/src/state/services/api-instance.ts
+++ b/src/state/services/api-instance.ts
@@ -6,5 +6,5 @@ export const apiInstance = createApi({
     reducerPath: "api",
     baseQuery: axiosBaseQuery({ baseUrl: ENV.BASE_URL }),
     endpoints: () => ({}),
-    tagTypes: ["batches", "courses-with-departments", "courses", "departments", "students", "student", "faculty", "faculty-detail"],
+    tagTypes: ["batches", "courses-with-departments", "courses", "departments", "all-departments", "students", "student", "faculty", "faculty-detail"],
 });

--- a/src/state/services/endpoints/academics.ts
+++ b/src/state/services/endpoints/academics.ts
@@ -16,6 +16,7 @@ import {
     GetAvailableDepartmentsResponse,
     AddDepartmentToBatchCourseRequest,
     AddDepartmentToBatchCourseResponse,
+    GetAllDepartmentsResponse,
 } from "../../../types/academics-types";
 
 export const academicsApiService = apiInstance.injectEndpoints({
@@ -108,6 +109,13 @@ export const academicsApiService = apiInstance.injectEndpoints({
             }),
             providesTags: ['courses-with-departments'],
         }),
+        getAllDepartments: build.query<GetAllDepartmentsResponse, void>({
+            query: () => ({
+                url: api.academics.getAllDepartments(),
+                method: "GET",
+            }),
+            providesTags: ['all-departments'],
+        }),
     }),
 });
 
@@ -127,4 +135,6 @@ export const {
     useAddDepartmentToBatchCourseMutation,
     useGetCoursesWithDepartmentsQuery,
     useLazyGetCoursesWithDepartmentsQuery,
+    useGetAllDepartmentsQuery,
+    useLazyGetAllDepartmentsQuery,
 } = academicsApiService;

--- a/src/state/services/endpoints/faculty.ts
+++ b/src/state/services/endpoints/faculty.ts
@@ -4,6 +4,11 @@ import {
     GetAllFacultyResponse,
     GetFacultyResponse,
     BasePaginationParams,
+    CreateFacultyRequest,
+    CreateFacultyResponse,
+    EditFacultyRequest,
+    EditFacultyResponse,
+    DeleteFacultyResponse,
 } from "../../../types/faculty-types";
 
 export const facultyApiService = apiInstance.injectEndpoints({
@@ -27,6 +32,29 @@ export const facultyApiService = apiInstance.injectEndpoints({
             }),
             providesTags: ['faculty-detail'],
         }),
+        createFaculty: build.mutation<CreateFacultyResponse, CreateFacultyRequest>({
+            query: (data) => ({
+                url: api.faculty.createFaculty(),
+                method: "POST",
+                data,
+            }),
+            invalidatesTags: ['faculty'],
+        }),
+        updateFaculty: build.mutation<EditFacultyResponse, { id: string; data: EditFacultyRequest }>({
+            query: ({ id, data }) => ({
+                url: api.faculty.updateFaculty(id),
+                method: "PATCH",
+                data,
+            }),
+            invalidatesTags: ['faculty', 'faculty-detail'],
+        }),
+        deleteFaculty: build.mutation<DeleteFacultyResponse, string>({
+            query: (id) => ({
+                url: api.faculty.deleteFaculty(id),
+                method: "DELETE",
+            }),
+            invalidatesTags: ['faculty', 'faculty-detail'],
+        }),
     }),
 });
 
@@ -35,4 +63,7 @@ export const {
     useLazyGetAllFacultyQuery,
     useGetFacultyByIdQuery,
     useLazyGetFacultyByIdQuery,
+    useCreateFacultyMutation,
+    useUpdateFacultyMutation,
+    useDeleteFacultyMutation,
 } = facultyApiService;

--- a/src/state/services/endpoints/students.ts
+++ b/src/state/services/endpoints/students.ts
@@ -4,6 +4,11 @@ import {
     GetAllStudentsResponse,
     GetStudentResponse,
     BasePaginationParams,
+    CreateStudentRequest,
+    CreateStudentResponse,
+    EditStudentRequest,
+    EditStudentResponse,
+    DeleteStudentResponse,
 } from "../../../types/students-types";
 
 export const studentsApiService = apiInstance.injectEndpoints({
@@ -27,6 +32,29 @@ export const studentsApiService = apiInstance.injectEndpoints({
             }),
             providesTags: ['student'],
         }),
+        createStudent: build.mutation<CreateStudentResponse, CreateStudentRequest>({
+            query: (data) => ({
+                url: api.students.createStudent(),
+                method: "POST",
+                data,
+            }),
+            invalidatesTags: ['students'],
+        }),
+        updateStudent: build.mutation<EditStudentResponse, { id: string; data: EditStudentRequest }>({
+            query: ({ id, data }) => ({
+                url: api.students.updateStudent(id),
+                method: "PATCH",
+                data,
+            }),
+            invalidatesTags: ['students', 'student'],
+        }),
+        deleteStudent: build.mutation<DeleteStudentResponse, string>({
+            query: (id) => ({
+                url: api.students.deleteStudent(id),
+                method: "DELETE",
+            }),
+            invalidatesTags: ['students', 'student'],
+        }),
     }),
 });
 
@@ -35,4 +63,7 @@ export const {
     useLazyGetAllStudentsQuery,
     useGetStudentByIdQuery,
     useLazyGetStudentByIdQuery,
+    useCreateStudentMutation,
+    useUpdateStudentMutation,
+    useDeleteStudentMutation,
 } = studentsApiService;

--- a/src/types/academics-types.ts
+++ b/src/types/academics-types.ts
@@ -148,6 +148,13 @@ export interface GetAvailableDepartmentsResponse {
     data?: DepartmentInfo[];
 }
 
+// All Departments Types (unscoped - used for Faculty department dropdown)
+export interface GetAllDepartmentsResponse {
+    success: boolean;
+    message: string;
+    data?: DepartmentInfo[];
+}
+
 // Add Department to Batch Course Types
 export interface AddDepartmentToBatchCourseRequest {
     batchCourseId: string;

--- a/src/types/faculty-types.ts
+++ b/src/types/faculty-types.ts
@@ -150,3 +150,76 @@ export interface GetFacultyResponse {
     message: string;
     data?: FacultyDetailData;
 }
+
+// Create / Edit Faculty Types
+export interface FacultyEducationHistoryInput {
+    level: string;
+    qualification: string;
+    boardOrUniversity: string;
+    institutionName: string;
+    yearOfPassing: number;
+    percentageOrCGPA: number;
+    specialization?: string;
+}
+
+export interface FacultyWorkExperienceInput {
+    organization: string;
+    role: string;
+    department?: string;
+    fromDate: string;
+    toDate: string;
+    experienceYears: number;
+    jobDescription?: string;
+    reasonForLeaving?: string;
+    isCurrent?: boolean;
+}
+
+export interface CreateFacultyRequest {
+    firstName: string;
+    lastName: string;
+    gender: string;
+    dateOfBirth: string;
+    maritalStatus: string;
+    profilePhotoUrl: string;
+    religion?: string;
+
+    personalEmail: string;
+    phoneNumber: string;
+    alternatePhoneNumber?: string;
+    emergencyContact: EmergencyContact;
+
+    currentAddress: Address;
+    sameAsCurrent: boolean;
+    permanentAddress?: Address;
+
+    employeeId: string;
+    designation: string;
+    departmentId: string;
+    employmentType: string;
+    totalExperienceYears: number;
+    highestQualification: string;
+    remarks?: string;
+
+    educationHistory: FacultyEducationHistoryInput[];
+    workExperience?: FacultyWorkExperienceInput[];
+}
+
+export interface CreateFacultyResponse {
+    success: boolean;
+    message: string;
+}
+
+export type EditFacultyRequest = Omit<
+    CreateFacultyRequest,
+    "employeeId" | "designation" | "departmentId" | "employmentType" | "totalExperienceYears" | "highestQualification" | "remarks"
+>;
+
+export interface EditFacultyResponse {
+    success: boolean;
+    message: string;
+}
+
+export interface DeleteFacultyResponse {
+    success: boolean;
+    message: string;
+}

--- a/src/types/students-types.ts
+++ b/src/types/students-types.ts
@@ -154,3 +154,75 @@ export interface GetStudentResponse {
     message: string;
     data?: StudentData;
 }
+
+// Create / Edit Student Types
+export interface EducationHistoryInput {
+    level: string;
+    qualification: string;
+    boardOrUniversity: string;
+    institutionName: string;
+    yearOfPassing: number;
+    percentageOrCGPA: number;
+}
+
+export interface ParentInfoInput {
+    name?: string;
+    phoneNumber?: string;
+    email?: string;
+    occupation?: string;
+}
+
+export interface GuardianInfoInput extends ParentInfoInput {
+    relation?: string;
+}
+
+export interface CreateStudentRequest {
+    firstName: string;
+    lastName: string;
+    gender: string;
+    dateOfBirth: string;
+    profilePhotoUrl: string;
+    religion?: string;
+
+    personalEmail: string;
+    phoneNumber: string;
+    alternatePhoneNumber?: string;
+    emergencyContact: EmergencyContact;
+
+    currentAddress: Address;
+    sameAsCurrent: boolean;
+    permanentAddress?: Address;
+
+    batchId: string;
+    courseId: string;
+    departmentId: string;
+    sectionId: string;
+    currentSemester: number;
+    admissionType: string;
+
+    father?: ParentInfoInput;
+    mother?: ParentInfoInput;
+    guardian?: GuardianInfoInput;
+
+    educationHistory: EducationHistoryInput[];
+}
+
+export interface CreateStudentResponse {
+    success: boolean;
+    message: string;
+}
+
+export type EditStudentRequest = Omit<
+    CreateStudentRequest,
+    "batchId" | "courseId" | "departmentId" | "sectionId" | "currentSemester" | "admissionType"
+>;
+
+export interface EditStudentResponse {
+    success: boolean;
+    message: string;
+}
+
+export interface DeleteStudentResponse {
+    success: boolean;
+    message: string;
+}

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -3,3 +3,85 @@ export enum UserRole {
     FACULTY = "FACULTY",
     STUDENT = "STUDENT",
 }
+
+export enum Gender {
+    MALE = "MALE",
+    FEMALE = "FEMALE",
+    OTHERS = "OTHERS",
+}
+
+export enum MaritalStatus {
+    SINGLE = "SINGLE",
+    MARRIED = "MARRIED",
+    DIVORCED = "DIVORCED",
+    WIDOWED = "WIDOWED",
+}
+
+export enum Country {
+    INDIA = "INDIA",
+}
+
+export enum AdmissionType {
+    REGULAR = "REGULAR",
+    LATERAL = "LATERAL",
+    MANAGEMENT = "MANAGEMENT",
+}
+
+export enum EducationLevel {
+    SECONDARY = "SECONDARY",
+    HIGHER_SECONDARY = "HIGHER_SECONDARY",
+    DIPLOMA = "DIPLOMA",
+    UNDERGRADUATE = "UNDERGRADUATE",
+    POSTGRADUATE = "POSTGRADUATE",
+}
+
+export enum Qualification {
+    TENTH = "10th",
+    TWELFTH = "12th",
+    DIPLOMA = "Diploma",
+    DEGREE = "Degree",
+}
+
+export enum BoardType {
+    STATE_BOARD = "STATE_BOARD",
+    CBSE = "CBSE",
+    ICSE = "ICSE",
+    IB = "IB",
+    OTHER = "OTHER",
+}
+
+export enum RelationType {
+    FATHER = "FATHER",
+    MOTHER = "MOTHER",
+    GUARDIAN = "GUARDIAN",
+    RELATIVE = "RELATIVE",
+    OTHER = "OTHER",
+}
+
+export enum FacultyDesignation {
+    ASSISTANT_PROFESSOR = "ASSISTANT_PROFESSOR",
+    ASSOCIATE_PROFESSOR = "ASSOCIATE_PROFESSOR",
+    PROFESSOR = "PROFESSOR",
+    LECTURER = "LECTURER",
+    HOD = "HOD",
+    PRINCIPAL = "PRINCIPAL",
+}
+
+export enum EmploymentType {
+    PERMANENT = "PERMANENT",
+    CONTRACT = "CONTRACT",
+    VISITING = "VISITING",
+    GUEST = "GUEST",
+    ADJUNCT = "ADJUNCT",
+}
+
+export enum HighestQualification {
+    PhD = "PhD",
+    MTECH = "MTECH",
+    ME = "ME",
+    MBA = "MBA",
+    MSC = "MSC",
+    BE = "BE",
+    BTECH = "BTECH",
+    OTHER = "OTHER",
+}


### PR DESCRIPTION
Add full create/edit flows for Students and Faculties: pages, Formik forms, validation (Yup), shared form sections (address, emergency contact), and numerous form components (personal, contact, academic, employment, education, work experience, parent/guardian). Extend RTK Query with create/update/delete mutations for students & faculty and a getAllDepartments query. Add new request/response types and expand enums. Minor UI fixes: Table overflow -> overflow-x-auto and RootLayout min-w-0. Update routes to use new pages and replace in-list modals with dedicated pages; add delete confirmation modals on detail pages.